### PR TITLE
refactor: 💡 pagination functionality of page of red flags of address, hide sorting menu scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+12",
+  "version": "0.1.0+13",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+13",
+  "version": "0.1.0+14",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/components/block_produced_section/block_produced_section.tsx
+++ b/src/components/block_produced_section/block_produced_section.tsx
@@ -52,9 +52,6 @@ const BlockProducedHistorySection = ({
   const {t}: {t: TranslateFunction} = useTranslation('common');
 
   const [activePageDefault, setActivePageDefault] = useStateRef(1);
-  // const [totalPages, setTotalPages] = useState(
-  //   Math.ceil(addressDetailsCtx.producedBlocks.totalPage)
-  // );
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [searchDefault, setSearchDefault, searchRefDefault] = useStateRef('');
   const [sortingDefault, setSortingDefault] = useState<string>(sortOldAndNewOptions[0]);

--- a/src/components/red_flag_list/red_flag_list.tsx
+++ b/src/components/red_flag_list/red_flag_list.tsx
@@ -1,86 +1,104 @@
-import {useState, useEffect} from 'react';
+import {useState, Dispatch, SetStateAction} from 'react';
 import useStateRef from 'react-usestateref';
 import {ITEM_PER_PAGE, default30DayPeriod, sortOldAndNewOptions} from '../../constants/config';
 import Pagination from '../../components/pagination/pagination';
-import SearchBar from '../../components/search_bar/search_bar';
+import {SearchBarWithKeyDown} from '../../components/search_bar/search_bar';
 import SortingMenu from '../../components/sorting_menu/sorting_menu';
 import DatePicker from '../../components/date_picker/date_picker';
 import RedFlagItem from '../../components/red_flag_item/red_flag_item';
 import {useTranslation} from 'next-i18next';
 import {TranslateFunction} from '../../interfaces/locale';
 import {IRedFlag} from '../../interfaces/red_flag';
+import {IDatePeriod} from '../../interfaces/date_period';
+import Skeleton from '../skeleton/skeleton';
 
 interface IRedFlagListProps {
   redFlagData: IRedFlag[];
+
+  period?: IDatePeriod;
+  setPeriod?: Dispatch<SetStateAction<IDatePeriod>>;
+  sorting?: string;
+  setSorting?: Dispatch<SetStateAction<string>>;
+
+  setSearch?: Dispatch<SetStateAction<string>>;
+  activePage?: number;
+  setActivePage?: Dispatch<SetStateAction<number>>;
+  isLoading?: boolean;
+  totalPages?: number;
+
+  typeOptions?: string[];
+  filteredType?: string;
+  setFilteredType?: Dispatch<SetStateAction<string>>;
 }
 
-const RedFlagList = ({redFlagData}: IRedFlagListProps) => {
+const RedFlagListSkeleton = () => {
+  const listSkeletons = Array.from({length: ITEM_PER_PAGE}, (_, i) => (
+    <div key={i} className="flex w-full flex-col">
+      <div className="flex h-60px w-full items-center">
+        {/* Info: (20240227 - Shirley) Flagging Time square */}
+        <div className="flex w-60px flex-col items-center justify-center border-b border-darkPurple bg-darkPurple">
+          <Skeleton width={60} height={40} />{' '}
+        </div>
+        <div className="flex h-full flex-1 items-center border-b border-darkPurple4 pl-2 lg:pl-8">
+          {/* Info: (20240227 - Shirley) Address ID */}
+          <Skeleton width={150} height={40} /> {/* Info: (20240227 - Shirley) Flag Type */}
+          <div className="flex w-full justify-end">
+            <Skeleton width={80} height={40} />{' '}
+          </div>
+        </div>
+      </div>{' '}
+    </div>
+  ));
+  return (
+    <>
+      {/* Info: (20240227 - Shirley) Red Flag List */}
+      <div className="mb-10 mt-16 flex w-full flex-col items-center space-y-0 lg:mt-10">
+        {listSkeletons}
+        {/* Info: Pagination (20240223 - Shirley) */}
+      </div>
+      <div className="flex w-full justify-center">
+        <Skeleton width={200} height={40} />{' '}
+      </div>
+    </>
+  );
+};
+
+const RedFlagList = ({
+  redFlagData,
+  period,
+  setPeriod,
+  sorting,
+  setSorting,
+  setSearch,
+  activePage,
+  setActivePage,
+  isLoading,
+  totalPages,
+  typeOptions,
+  filteredType,
+  setFilteredType,
+}: IRedFlagListProps) => {
   const {t}: {t: TranslateFunction} = useTranslation('common');
 
   // Info: (20231109 - Julian) Type Options
-  const flaggingType = redFlagData.map(redFlagData => redFlagData.redFlagType);
-  const typeOptions = ['SORTING.ALL', ...flaggingType];
+  const typeOptionsDefault = ['SORTING.ALL'];
 
   // Info: (20231109 - Julian) States
-  const [search, setSearch, searchRef] = useStateRef('');
-  const [sorting, setSorting] = useState<string>(sortOldAndNewOptions[0]);
-  const [period, setPeriod] = useState(default30DayPeriod);
-  const [filteredType, setFilteredType] = useState<string>(typeOptions[0]);
-  const [filteredRedFlagList, setFilteredRedFlagList] = useState<IRedFlag[]>(redFlagData);
-  const [activePage, setActivePage] = useState<number>(1);
-  const [totalPages, setTotalPages] = useState<number>(
-    Math.ceil(redFlagData.length / ITEM_PER_PAGE)
-  );
+  const [activePageDefault, setActivePageDefault] = useStateRef(1);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [searchDefault, setSearchDefault] = useStateRef('');
+  const [sortingDefault, setSortingDefault] = useState<string>(sortOldAndNewOptions[0]);
+  const [periodDefault, setPeriodDefault] = useState(default30DayPeriod);
+  const [filteredTypeDefault, setFilteredTypeDefault] = useState<string>(typeOptionsDefault[0]);
 
-  // Info: (20231109 - Julian) Pagination Variables
-  const endIdx = activePage * ITEM_PER_PAGE;
-  const startIdx = endIdx - ITEM_PER_PAGE;
+  const isLoadingDefault = isLoading ?? false;
 
   // Info: (20231109 - Julian) Display Red Flag List Items based on Pagination
-  const displayRedFlagList = filteredRedFlagList
-    .slice(startIdx, endIdx)
-    .map((redFlagData, index) => <RedFlagItem key={index} redFlagData={redFlagData} />);
-
-  useEffect(() => {
-    const searchResult = redFlagData
-      // Info: (20231109 - Julian) filter by search term
-      .filter((redFlagDatElement: IRedFlag) => {
-        const searchTerm = searchRef.current.toLowerCase();
-        const type = redFlagDatElement.redFlagType.toLowerCase();
-        const id = redFlagDatElement.id.toLowerCase();
-
-        return searchTerm !== '' ? type.includes(searchTerm) || id.includes(searchTerm) : true;
-      })
-
-      // Info: (20231109 - Julian) filter by date range
-      .filter((redFlagData: IRedFlag) => {
-        const createdTimestamp = redFlagData.createdTimestamp;
-        const start = period.startTimeStamp;
-        const end = period.endTimeStamp;
-        // Info: (20231109 - Julian) if start and end are 0, it means that there is no period filter
-        const isCreatedTimestampInRange =
-          start === 0 && end === 0 ? true : createdTimestamp >= start && createdTimestamp <= end;
-
-        return isCreatedTimestampInRange;
-      })
-
-      // Info: (20231109 - Julian) filter by type
-      .filter((redFlagDatElement: IRedFlag) => {
-        const type = redFlagDatElement.redFlagType.toLowerCase();
-        return filteredType !== typeOptions[0] ? filteredType.toLowerCase().includes(type) : true;
-      })
-      // Info: (20231109 - Julian) sort by Newest or Oldest
-      .sort((a: IRedFlag, b: IRedFlag) => {
-        return sorting === sortOldAndNewOptions[0]
-          ? b.createdTimestamp - a.createdTimestamp
-          : a.createdTimestamp - b.createdTimestamp;
-      });
-
-    setFilteredRedFlagList(searchResult);
-    setActivePage(1);
-    setTotalPages(Math.ceil(searchResult.length / ITEM_PER_PAGE));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [redFlagData, filteredType, search, period, sorting]);
+  const displayRedFlagList = !isLoadingDefault ? (
+    redFlagData.map((redFlagData, index) => <RedFlagItem key={index} redFlagData={redFlagData} />)
+  ) : (
+    <RedFlagListSkeleton />
+  );
 
   return (
     <>
@@ -88,33 +106,36 @@ const RedFlagList = ({redFlagData}: IRedFlagListProps) => {
       <div className="flex w-full flex-col items-end space-y-10">
         {/* Info: (20231109 - Julian) Search Bar */}
         <div className="mx-auto my-5 w-full lg:w-7/10">
-          <SearchBar
-            searchBarPlaceholder={t('RED_FLAG_DETAIL_PAGE.SEARCH_PLACEHOLDER')}
-            setSearch={setSearch}
-          />
+          {SearchBarWithKeyDown({
+            searchBarPlaceholder: t('RED_FLAG_DETAIL_PAGE.SEARCH_PLACEHOLDER'),
+            setSearch: setSearch ?? setSearchDefault,
+          })}
         </div>
         <div className="flex w-full flex-col items-center gap-2 lg:h-72px lg:flex-row lg:justify-between">
           {/* Info: (20231109 - Julian) Type Select Menu */}
           <div className="relative flex w-full items-center space-y-2 text-base lg:w-fit">
             <SortingMenu
-              sortingOptions={typeOptions}
-              sorting={filteredType}
-              setSorting={setFilteredType}
+              sortingOptions={typeOptions ?? typeOptionsDefault}
+              sorting={filteredType ?? filteredTypeDefault}
+              setSorting={setFilteredType ?? setFilteredTypeDefault}
               bgColor="bg-darkPurple"
             />
           </div>
           {/* Info: (20231109 - Julian) Date Picker */}
           <div className="flex w-full items-center text-sm lg:w-fit lg:space-x-2">
             <p className="hidden text-lilac lg:block">{t('DATE_PICKER.DATE')} :</p>
-            <DatePicker period={period} setFilteredPeriod={setPeriod} />
+            <DatePicker
+              period={period ?? periodDefault}
+              setFilteredPeriod={setPeriod ?? setPeriodDefault}
+            />
           </div>
           {/* Info: (20231109 - Julian) Sorting Menu */}
           <div className="relative flex w-full items-center text-sm lg:w-fit lg:space-x-2">
             <p className="hidden text-lilac lg:block">{t('SORTING.SORT_BY')} :</p>
             <SortingMenu
               sortingOptions={sortOldAndNewOptions}
-              sorting={sorting}
-              setSorting={setSorting}
+              sorting={sorting ?? sortingDefault}
+              setSorting={setSorting ?? setSortingDefault}
               bgColor="bg-darkPurple"
             />
           </div>
@@ -124,7 +145,11 @@ const RedFlagList = ({redFlagData}: IRedFlagListProps) => {
       {/* Info: (20231109 - Julian) Red Flag List */}
       <div className="mt-10 flex w-full flex-col items-center space-y-10">
         <div className="flex w-full flex-col">{displayRedFlagList}</div>
-        <Pagination activePage={activePage} setActivePage={setActivePage} totalPages={totalPages} />
+        <Pagination
+          activePage={activePage ?? activePageDefault}
+          setActivePage={setActivePage ?? setActivePageDefault}
+          totalPages={totalPages ?? 0}
+        />
       </div>
     </>
   );

--- a/src/components/red_flag_list/red_flag_list.tsx
+++ b/src/components/red_flag_list/red_flag_list.tsx
@@ -54,10 +54,6 @@ const RedFlagListSkeleton = () => {
       {/* Info: (20240227 - Shirley) Red Flag List */}
       <div className="mb-10 mt-16 flex w-full flex-col items-center space-y-0 lg:mt-10">
         {listSkeletons}
-        {/* Info: Pagination (20240223 - Shirley) */}
-      </div>
-      <div className="flex w-full justify-center">
-        <Skeleton width={200} height={40} />{' '}
       </div>
     </>
   );

--- a/src/interfaces/red_flag.ts
+++ b/src/interfaces/red_flag.ts
@@ -22,3 +22,10 @@ export interface IRedFlagDetail extends IRedFlagSearchResult {
   totalAmount: string; // Info:(20231228 - Julian) 交易總金額
   transactionHistoryData: ITransaction[]; // Info:(20231228 - Julian) 被警示的交易記錄
 }
+
+export interface IRedFlagOfAddress {
+  redFlagData: IRedFlag[];
+  redFlagCount: number;
+  totalPage: number;
+  allRedFlagTypes: string[];
+}

--- a/src/pages/api/v1/app/chains/[chains_id]/addresses/[address_id]/produced_blocks.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/addresses/[address_id]/produced_blocks.ts
@@ -5,6 +5,7 @@ import {AddressType} from '../../../../../../../../interfaces/address_info';
 import {IAddressProducedBlock} from '../../../../../../../../interfaces/address';
 import {IProductionBlock} from '../../../../../../../../interfaces/block';
 import prisma from '../../../../../../../../../prisma/client';
+import {DEFAULT_PAGE} from '../../../../../../../../constants/config';
 
 type ResponseData = IAddressProducedBlock | undefined;
 
@@ -13,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const chain_id =
     typeof req.query.chains_id === 'string' ? parseInt(req.query.chains_id) : undefined;
   const order = (req.query.order as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc';
-  const page = typeof req.query.page === 'string' ? parseInt(req.query.page, 10) : 0;
+  const page = typeof req.query.page === 'string' ? parseInt(req.query.page, 10) : DEFAULT_PAGE;
   const offset = typeof req.query.offset === 'string' ? parseInt(req.query.offset, 10) : 10;
   const start_date =
     typeof req.query.start_date === 'string' && parseInt(req.query.start_date, 10) > 0

--- a/src/pages/api/v1/app/chains/[chains_id]/addresses/[address_id]/red_flags.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/addresses/[address_id]/red_flags.ts
@@ -1,38 +1,40 @@
 // 013 - GET /app/chains/:chain_id/addresses/:address_id/red_flags
 
 import type {NextApiRequest, NextApiResponse} from 'next';
-import {IRedFlag} from '../../../../../../../../interfaces/red_flag';
-import {RED_FLAG_CODE_WHEN_NULL} from '../../../../../../../../constants/config';
+import {IRedFlag, IRedFlagOfAddress} from '../../../../../../../../interfaces/red_flag';
+import {
+  DEFAULT_PAGE,
+  ITEM_PER_PAGE,
+  RED_FLAG_CODE_WHEN_NULL,
+} from '../../../../../../../../constants/config';
 import prisma from '../../../../../../../../../prisma/client';
 
-type ResponseData = IRedFlag[];
+type ResponseData = IRedFlagOfAddress;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
   const chain_id =
     typeof req.query.chains_id === 'string' ? parseInt(req.query.chains_id, 10) : undefined;
   const address_id = typeof req.query.address_id === 'string' ? req.query.address_id : undefined;
+  const order = (req.query.order as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc';
+  const page = typeof req.query.page === 'string' ? parseInt(req.query.page, 10) : DEFAULT_PAGE;
+  const offset =
+    typeof req.query.offset === 'string' ? parseInt(req.query.offset, 10) : ITEM_PER_PAGE;
+  const start_date =
+    typeof req.query.start_date === 'string' && parseInt(req.query.start_date, 10) > 0
+      ? parseInt(req.query.start_date, 10)
+      : undefined;
+  const end_date =
+    typeof req.query.end_date === 'string' && parseInt(req.query.end_date, 10) > 0
+      ? parseInt(req.query.end_date, 10)
+      : undefined;
+  const search = typeof req.query.search === 'string' ? req.query.search : undefined;
+  const type = typeof req.query.type === 'string' ? req.query.type : undefined;
 
   if (!chain_id || !address_id) {
-    return res.status(400).json([]);
+    return res.status(400).json({} as ResponseData);
   }
 
   try {
-    const redFlags = await prisma.red_flags.findMany({
-      where: {
-        chain_id,
-        related_addresses: {
-          hasSome: [address_id],
-        },
-      },
-      select: {
-        id: true,
-        chain_id: true,
-        red_flag_type: true,
-        created_timestamp: true,
-        related_addresses: true,
-      },
-    });
-
     const redFlagCodes = await prisma.codes.findMany({
       where: {
         table_name: 'red_flags',
@@ -44,11 +46,78 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       },
     });
 
-    const result = redFlags.map(redFlag => {
+    // Info: create map to store red flag type (20240304 - Shirley)
+    const typeCodeToMeaningMap = new Map<number, string>();
+    const typeMeaningToCodeMap = new Map<string, number>();
+
+    redFlagCodes.forEach(code => {
+      typeCodeToMeaningMap.set(code.value ?? RED_FLAG_CODE_WHEN_NULL, code.meaning ?? '');
+      typeMeaningToCodeMap.set(code.meaning ?? '', code.value ?? RED_FLAG_CODE_WHEN_NULL);
+    });
+
+    const skip = page > 0 ? (page - 1) * offset : 0;
+
+    const whereClause = {
+      chain_id,
+      AND: [
+        {related_addresses: {has: address_id}},
+        ...(search ? [{related_addresses: {has: search}}] : []),
+      ],
+      ...(start_date && end_date ? {created_timestamp: {gte: start_date, lte: end_date}} : {}),
+    };
+
+    const whereClauseWithType = {
+      ...whereClause,
+      ...(type ? {red_flag_type: typeMeaningToCodeMap.get(type)?.toString() ?? ''} : {}),
+    };
+
+    // Info: get all red flag types that has been happened to this address whatever the `type` parameter is (20240304 - Shirley)
+    const allPossibleRedFlagTypes = await prisma.red_flags.findMany({
+      where: {
+        ...whereClause,
+      },
+      select: {
+        red_flag_type: true,
+      },
+    });
+
+    const typesSet = new Set<string>();
+
+    allPossibleRedFlagTypes.forEach(redFlag => {
+      typesSet.add(
+        typeCodeToMeaningMap.get(
+          !!redFlag.red_flag_type ? +redFlag.red_flag_type : RED_FLAG_CODE_WHEN_NULL
+        ) ?? ''
+      );
+    });
+
+    // Info: red flag data that accord to parameters (20240304 - Shirley)
+    const redFlags = await prisma.red_flags.findMany({
+      where: {
+        ...whereClauseWithType,
+      },
+      orderBy: [{created_timestamp: order}, {id: order}],
+      take: offset,
+      skip,
+      select: {
+        id: true,
+        chain_id: true,
+        red_flag_type: true,
+        created_timestamp: true,
+        related_addresses: true,
+      },
+    });
+
+    const redFlagCount = await prisma.red_flags.count({where: whereClauseWithType});
+    const totalPage = await prisma.red_flags
+      .count({where: whereClauseWithType})
+      .then(count => Math.ceil(count / offset));
+
+    const redFlagData = redFlags.map(redFlag => {
       const redFlagTypeCode = redFlag.red_flag_type
         ? +redFlag.red_flag_type
         : RED_FLAG_CODE_WHEN_NULL;
-      const redFlagType = redFlagCodes.find(code => code.value === redFlagTypeCode)?.meaning ?? '';
+      const redFlagType = typeCodeToMeaningMap.get(redFlagTypeCode) ?? '';
 
       return {
         id: `${redFlag.id}`,
@@ -63,10 +132,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       };
     });
 
+    const result = {
+      redFlagCount,
+      totalPage,
+      redFlagData,
+      allRedFlagTypes: Array.from(typesSet),
+    };
+
     res.status(200).json(result);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.log('Error in /app/chains/:chain_id/addresses/:address_id/red_flags', error);
-    res.status(500).json([] as ResponseData);
+    res.status(500).json({} as ResponseData);
   }
 }

--- a/src/pages/app/chains/[chainId]/address/[addressId]/red-flag.tsx
+++ b/src/pages/app/chains/[chainId]/address/[addressId]/red-flag.tsx
@@ -3,130 +3,88 @@ import Image from 'next/image';
 import {useRouter} from 'next/router';
 import {useTranslation} from 'next-i18next';
 import {serverSideTranslations} from 'next-i18next/serverSideTranslations';
-import {GetStaticPaths, GetStaticProps} from 'next';
+import {GetServerSideProps, GetStaticPaths, GetStaticProps} from 'next';
 import NavBar from '../../../../../../components/nav_bar/nav_bar';
 import BoltButton from '../../../../../../components/bolt_button/bolt_button';
 import Footer from '../../../../../../components/footer/footer';
 import {BsArrowLeftShort} from 'react-icons/bs';
-import {getChainIcon, truncateText} from '../../../../../../lib/common';
+import {convertStringToSortingType, getChainIcon, truncateText} from '../../../../../../lib/common';
 import {TranslateFunction} from '../../../../../../interfaces/locale';
-import {IRedFlag} from '../../../../../../interfaces/red_flag';
+import {IRedFlag, IRedFlagOfAddress} from '../../../../../../interfaces/red_flag';
 import RedFlagList from '../../../../../../components/red_flag_list/red_flag_list';
 import {useContext, useEffect, useState} from 'react';
 import {AppContext} from '../../../../../../contexts/app_context';
 import {MarketContext} from '../../../../../../contexts/market_context';
 import {
   DEFAULT_CHAIN_ICON,
+  DEFAULT_PAGE,
   DEFAULT_RED_FLAG_COUNT_IN_PAGE,
   DEFAULT_TRUNCATE_LENGTH,
+  ITEM_PER_PAGE,
+  default30DayPeriod,
+  sortOldAndNewOptions,
 } from '../../../../../../constants/config';
 import Skeleton from '../../../../../../components/skeleton/skeleton';
+import useAPIResponse from '../../../../../../lib/hooks/use_api_response';
+import {APIURL} from '../../../../../../constants/api_request';
+import {IDatePeriod} from '../../../../../../interfaces/date_period';
 
 interface IRedFlagOfAddressPageProps {
   chainId: string;
   addressId: string;
 }
 
-const RedFlagListSkeleton = () => {
-  const listSkeletons = Array.from({length: DEFAULT_RED_FLAG_COUNT_IN_PAGE}, (_, i) => (
-    <div key={i} className="flex w-full flex-col">
-      <div className="flex h-60px w-full items-center">
-        {/* Info: (20240227 - Shirley) Flagging Time square */}
-        <div className="flex w-60px flex-col items-center justify-center border-b border-darkPurple bg-darkPurple">
-          <Skeleton width={60} height={40} />{' '}
-        </div>
-        <div className="flex h-full flex-1 items-center border-b border-darkPurple4 pl-2 lg:pl-8">
-          {/* Info: (20240227 - Shirley) Address ID */}
-          <Skeleton width={150} height={40} /> {/* Info: (20240227 - Shirley) Flag Type */}
-          <div className="flex w-full justify-end">
-            <Skeleton width={80} height={40} />{' '}
-          </div>
-        </div>
-      </div>{' '}
-    </div>
-  ));
-  return (
-    <>
-      {/* Info: (20240227 - Shirley) Search Filter */}
-      <div className="flex w-full flex-col items-end space-y-10">
-        {/* Info: (20240227 - Shirley) Search Bar */}
-        <div className="mx-auto my-5 flex w-full justify-center lg:w-7/10">
-          <Skeleton width={800} height={40} />
-        </div>
-        <div className="flex w-full flex-col items-center gap-2 lg:h-72px lg:flex-row lg:justify-between">
-          {/* Info: (20240227 - Shirley) Type Select Menu */}
-          <div className="relative flex w-full items-center space-y-2 text-base lg:w-200px">
-            <Skeleton width={1023} height={40} />
-          </div>
-          {/* Info: (20240227 - Shirley) Date Picker */}
-          <div className="flex w-full items-center text-sm lg:w-220px lg:space-x-2">
-            <Skeleton width={1023} height={40} />{' '}
-          </div>
-          {/* Info: (20240227 - Shirley) Sorting Menu */}
-          <div className="relative flex w-full items-center text-sm lg:w-220px lg:space-x-2">
-            <Skeleton width={1023} height={40} />
-          </div>
-        </div>
-      </div>
-
-      {/* Info: (20240227 - Shirley) Red Flag List */}
-      <div className="mb-10 mt-16 flex w-full flex-col items-center space-y-0 lg:mt-10">
-        {listSkeletons}
-        {/* Info: Pagination (20240223 - Shirley) */}
-      </div>
-      <div className="flex w-full justify-center">
-        <Skeleton width={200} height={40} />{' '}
-      </div>
-    </>
-  );
-};
-
 const RedFlagOfAddressPage = ({chainId, addressId}: IRedFlagOfAddressPageProps) => {
   const {t}: {t: TranslateFunction} = useTranslation('common');
   const router = useRouter();
-  const appCtx = useContext(AppContext);
-  const {getRedFlagsFromAddress} = useContext(MarketContext);
+  const {page} = router.query;
 
   const headTitle = `${t('RED_FLAG_DETAIL_PAGE.BREADCRUMB_TITLE')} ${t('COMMON.OF')} ${t(
     'ADDRESS_DETAIL_PAGE.MAIN_TITLE'
   )} ${addressId} - BAIFA`;
   const chainIcon = getChainIcon(chainId);
 
-  const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [redFlagData, setRedFlagData] = useState<IRedFlag[]>([]);
+  const [search, setSearch] = useState<string>('');
+  const [period, setPeriod] = useState<IDatePeriod>(default30DayPeriod);
+  const [sorting, setSorting] = useState<string>(sortOldAndNewOptions[0]);
+  const [activePage, setActivePage] = useState<number>(page ? +page : DEFAULT_PAGE);
+  const [filteredType, setFilteredType] = useState<string>('SORTING.ALL');
 
-  const getRedFlagData = async (chainId: string, addressId: string) => {
-    try {
-      const redFlagData = await getRedFlagsFromAddress(chainId, addressId);
-      setRedFlagData(redFlagData);
-    } catch (error) {
-      // console.log('getRedFlagData error', error);
+  const {data, isLoading, error} = useAPIResponse<IRedFlagOfAddress>(
+    `${APIURL.CHAINS}/${chainId}/addresses/${addressId}/red_flags`,
+    {
+      search: search,
+      start_date: period.startTimeStamp === 0 ? '' : period.startTimeStamp,
+      end_date: period.endTimeStamp === 0 ? '' : period.endTimeStamp,
+      order: convertStringToSortingType(sorting),
+      page: activePage,
+      offset: ITEM_PER_PAGE,
+      type: filteredType === 'SORTING.ALL' ? '' : filteredType,
     }
-  };
+  );
 
-  useEffect(() => {
-    if (!appCtx.isInit) {
-      appCtx.init();
-    }
-
-    (async () => {
-      setIsLoading(true);
-      await getRedFlagData(chainId, addressId);
-      setIsLoading(false);
-    })();
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const typeOptions = ['SORTING.ALL', ...(data?.allRedFlagTypes ?? [])];
 
   const backClickHandler = () => router.back();
 
-  const displayedRedFlagList = !isLoading ? (
-    <RedFlagList redFlagData={redFlagData} />
-  ) : (
-    <RedFlagListSkeleton />
+  const displayedRedFlagList = (
+    <RedFlagList
+      redFlagData={data?.redFlagData ?? []}
+      period={period}
+      setPeriod={setPeriod}
+      sorting={sorting}
+      setSorting={setSorting}
+      activePage={activePage}
+      setActivePage={setActivePage}
+      totalPages={data?.totalPage ?? 0}
+      setSearch={setSearch}
+      isLoading={isLoading}
+      filteredType={filteredType}
+      setFilteredType={setFilteredType}
+      typeOptions={typeOptions}
+    />
   );
-
-  const displayedAddress = !isLoading ? (
+  const displayedAddress = (
     <div className="flex items-center space-x-2">
       <Image
         src={chainIcon.src}
@@ -139,8 +97,6 @@ const RedFlagOfAddressPage = ({chainId, addressId}: IRedFlagOfAddressPageProps) 
         {t('ADDRESS_DETAIL_PAGE.MAIN_TITLE')} {truncateText(addressId, DEFAULT_TRUNCATE_LENGTH)}
       </p>{' '}
     </div>
-  ) : (
-    <Skeleton width={250} height={30} />
   );
 
   return (
@@ -200,37 +156,13 @@ const RedFlagOfAddressPage = ({chainId, addressId}: IRedFlagOfAddressPageProps) 
 
 export default RedFlagOfAddressPage;
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  // ToDo: (20231213 - Julian) Add dynamic paths
-  const paths = [
-    {
-      params: {chainId: 'isun', addressId: '1'},
-      locale: 'en',
-    },
-  ];
-
-  return {paths, fallback: 'blocking'};
-};
-
-export const getStaticProps: GetStaticProps<IRedFlagOfAddressPageProps> = async ({
-  params,
-  locale,
-}) => {
-  if (!params || !params.addressId || typeof params.addressId !== 'string') {
-    return {
-      notFound: true,
-    };
-  }
-  if (!params || !params.chainId || typeof params.chainId !== 'string') {
-    return {
-      notFound: true,
-    };
-  }
-
-  const addressId = params.addressId;
-  const chainId = params.chainId;
-
+export const getServerSideProps: GetServerSideProps = async ({query, locale}) => {
+  const {chainId = '', addressId = ''} = query;
   return {
-    props: {addressId, chainId, ...(await serverSideTranslations(locale as string, ['common']))},
+    props: {
+      chainId,
+      addressId,
+      ...(await serverSideTranslations(locale as string, ['common'])),
+    },
   };
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,6 +20,15 @@ div::-webkit-scrollbar {
   display: none;
 }
 
+ul {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+ul::-webkit-scrollbar {
+  display: none;
+}
+
 input[type='number']::-webkit-outer-spin-button,
 input[type='number']::-webkit-inner-spin-button {
   -webkit-appearance: none;


### PR DESCRIPTION
### DEVELOP

- 重構 /[addressId]/red-flags 頁面並且 fix **URL 跟畫面沒有對齊** bug，詳細作法參考 https://github.com/CAFECA-IO/BAIFA/issues/795#issuecomment-1976107123
- 修改 sorting menu 卷軸


### CHECK LIST

- [Naming convention](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md) verification: checked
- Coding style verification: checked
- new Library: 0
- new Class / Component:  0
- new loop: 2
    - src/pages/api/v1/app/chains/[chains_id]/addresses/[address_id]/red_flags.ts (53, 86)
- high risk: 0
- new sql: 0
