### PR TITLE
refactor: 💡 pagination function of searching result page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+18",
+  "version": "0.1.0+19",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+16",
+  "version": "0.1.0+17",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+15",
+  "version": "0.1.0+16",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+14",
+  "version": "0.1.0+15",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+19",
+  "version": "0.1.0+20",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.0+17",
+  "version": "0.1.0+18",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -234,7 +234,9 @@ export const THRESHOLD_FOR_ADDRESS_RISK_LEVEL = {
   LOW: 10,
 };
 
-// Info: 為 public_tags table 的 tag_type 欄位 (20240301 - Shirley)
-export const TAG_TYPE = {
-  BLACKLIST: '9',
+// Info: Documents/BFA/db_schema 寫定的 public_tags table 的 tag_type 欄位，因為不需要從 codes table 動態對照，所以先寫 static object 以利後續維護 (20240301 - Shirley)
+export const PUBLIC_TAGS_REFERENCE = {
+  TAG_TYPE: {
+    BLACKLIST: '9',
+  },
 };

--- a/src/constants/search_type.ts
+++ b/src/constants/search_type.ts
@@ -1,4 +1,5 @@
 export type ISearchType =
+  | 'ALL'
   | 'BLOCK'
   | 'ADDRESS'
   | 'CONTRACT'
@@ -8,6 +9,7 @@ export type ISearchType =
   | 'RED_FLAG';
 
 export type ISearchTypeConstant = {
+  ALL: ISearchType;
   BLOCK: ISearchType;
   ADDRESS: ISearchType;
   CONTRACT: ISearchType;
@@ -18,6 +20,7 @@ export type ISearchTypeConstant = {
 };
 
 export const SearchType: ISearchTypeConstant = {
+  ALL: 'ALL',
   BLOCK: 'BLOCK',
   ADDRESS: 'ADDRESS',
   CONTRACT: 'CONTRACT',
@@ -26,3 +29,7 @@ export const SearchType: ISearchTypeConstant = {
   BLACKLIST: 'BLACKLIST',
   RED_FLAG: 'RED_FLAG',
 };
+
+export function isSearchType(param: any): param is ISearchType {
+  return Object.values(SearchType).includes(param);
+}

--- a/src/interfaces/search_result.ts
+++ b/src/interfaces/search_result.ts
@@ -1,4 +1,4 @@
-import {ISearchType} from '../constants/search_type';
+import {ISearchType, SearchType} from '../constants/search_type';
 import {IBlock} from './block';
 import {IAddress} from './address';
 import {IContract} from './contract';
@@ -18,3 +18,44 @@ export interface ISearchResult {
     | IRedFlagSearchResult
     | IBlackList;
 }
+
+export interface ISearchResultData {
+  type: ISearchType;
+
+  count: number;
+  totalPage: number;
+  data: ISearchResult[];
+}
+
+export const filterTabs = [
+  'SEARCHING_RESULT_PAGE.ALL_TAB', // Info:(20231228 - Julian) All
+  'SEARCHING_RESULT_PAGE.BLOCKS_TAB', // Info:(20231228 - Julian) Blocks
+  'SEARCHING_RESULT_PAGE.ADDRESSES_TAB', // Info:(20231228 - Julian) Addresses
+  'SEARCHING_RESULT_PAGE.CONTRACTS_TAB', // Info:(20231228 - Julian) Contracts
+  'SEARCHING_RESULT_PAGE.EVIDENCES_TAB', // Info:(20231228 - Julian) Evidences
+  'SEARCHING_RESULT_PAGE.TRANSACTIONS_TAB', // Info:(20231228 - Julian) Transactions
+  'SEARCHING_RESULT_PAGE.BLACKLIST_TAB', // Info:(20231228 - Julian) Black List
+  'SEARCHING_RESULT_PAGE.RED_FLAGS_TAB', // Info:(20231228 - Julian) Red Flags
+];
+
+export const filterTabsToSearchType = new Map([
+  ['SEARCHING_RESULT_PAGE.ALL_TAB', SearchType.ALL],
+  ['SEARCHING_RESULT_PAGE.BLOCKS_TAB', SearchType.BLOCK],
+  ['SEARCHING_RESULT_PAGE.ADDRESSES_TAB', SearchType.ADDRESS],
+  ['SEARCHING_RESULT_PAGE.CONTRACTS_TAB', SearchType.CONTRACT],
+  ['SEARCHING_RESULT_PAGE.EVIDENCES_TAB', SearchType.EVIDENCE],
+  ['SEARCHING_RESULT_PAGE.TRANSACTIONS_TAB', SearchType.TRANSACTION],
+  ['SEARCHING_RESULT_PAGE.BLACKLIST_TAB', SearchType.BLACKLIST],
+  ['SEARCHING_RESULT_PAGE.RED_FLAGS_TAB', SearchType.RED_FLAG],
+]);
+
+export const searchTypeToFilterTabs = new Map([
+  [SearchType.ALL, 'SEARCHING_RESULT_PAGE.ALL_TAB'],
+  [SearchType.BLOCK, 'SEARCHING_RESULT_PAGE.BLOCKS_TAB'],
+  [SearchType.ADDRESS, 'SEARCHING_RESULT_PAGE.ADDRESSES_TAB'],
+  [SearchType.CONTRACT, 'SEARCHING_RESULT_PAGE.CONTRACTS_TAB'],
+  [SearchType.EVIDENCE, 'SEARCHING_RESULT_PAGE.EVIDENCES_TAB'],
+  [SearchType.TRANSACTION, 'SEARCHING_RESULT_PAGE.TRANSACTIONS_TAB'],
+  [SearchType.BLACKLIST, 'SEARCHING_RESULT_PAGE.BLACKLIST_TAB'],
+  [SearchType.RED_FLAG, 'SEARCHING_RESULT_PAGE.RED_FLAGS_TAB'],
+]);

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -260,7 +260,7 @@ export function convertStringToSortingType(sorting: string): IPaginationOptions[
       order = SortingType.ASC;
       break;
     default:
-      order = SortingType.ASC;
+      order = SortingType.DESC;
       break;
   }
 

--- a/src/pages/api/v1/app/index.ts
+++ b/src/pages/api/v1/app/index.ts
@@ -3,7 +3,7 @@
 import type {NextApiRequest, NextApiResponse} from 'next';
 import {IPromotion} from '../../../../interfaces/promotion';
 import prisma from '../../../../../prisma/client';
-import {TAG_TYPE} from '../../../../constants/config';
+import {PUBLIC_TAGS_REFERENCE} from '../../../../constants/config';
 
 type ResponseData = IPromotion;
 
@@ -15,7 +15,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     // Info: (20240216 - Shirley) Count public tags where tag_type equals "9" as blacklist
     const blackListLength = await prisma.public_tags.count({
       where: {
-        tag_type: TAG_TYPE.BLACKLIST,
+        tag_type: PUBLIC_TAGS_REFERENCE.TAG_TYPE.BLACKLIST,
       },
     });
     const result: ResponseData = {

--- a/src/pages/api/v1/app/search.ts
+++ b/src/pages/api/v1/app/search.ts
@@ -1590,6 +1590,10 @@ async function countResultsByType(
   // Function to count the results based on type and input without actually retrieving all data
   // Use similar logic to searchByType but for counting
   // Return the count as a number
+  const whereClause = {
+    ...(start_date && end_date ? {created_timestamp: {gte: start_date, lte: end_date}} : {}),
+  };
+
   switch (type) {
     case SearchType.BLOCK:
       // Count blocks matching the search input
@@ -1597,6 +1601,7 @@ async function countResultsByType(
 
       const blocksCount = await prisma.blocks.count({
         where: {
+          ...whereClause,
           number: searchId,
         },
       });
@@ -1610,6 +1615,7 @@ async function countResultsByType(
       // Count transactions matching the search input
       const transactionsCount = await prisma.transactions.count({
         where: {
+          ...whereClause,
           hash: {
             startsWith: searchInput,
           },
@@ -1621,6 +1627,7 @@ async function countResultsByType(
       // Count contracts matching the search input
       const contractsCount = await prisma.contracts.count({
         where: {
+          ...whereClause,
           contract_address: {
             startsWith: searchInput,
           },
@@ -1632,6 +1639,7 @@ async function countResultsByType(
       // Count evidences matching the search input
       const evidencesCount = await prisma.evidences.count({
         where: {
+          ...whereClause,
           OR: [
             {evidence_id: {startsWith: searchInput}},
             {contract_address: {startsWith: searchInput}},
@@ -1644,6 +1652,7 @@ async function countResultsByType(
       // Count red flags matching the search input
       const redFlagsCount = await prisma.red_flags.count({
         where: {
+          ...whereClause,
           related_addresses: {
             hasSome: [`${searchInput}`],
           },
@@ -1655,6 +1664,7 @@ async function countResultsByType(
       // Count addresses matching the search input
       const addressesCount = await prisma.addresses.count({
         where: {
+          ...whereClause,
           address: {
             startsWith: searchInput,
           },
@@ -1666,6 +1676,7 @@ async function countResultsByType(
       // Count blacklisted items matching the search input
       const blacklistedAddressesCount = await prisma.public_tags.count({
         where: {
+          ...whereClause,
           target: {
             startsWith: searchInput,
           },
@@ -1684,6 +1695,7 @@ async function countResultsByType(
 
       const countTx = await prisma.transactions.count({
         where: {
+          ...whereClause,
           hash: {
             startsWith: searchInput,
           },
@@ -1692,6 +1704,8 @@ async function countResultsByType(
 
       const countContract = await prisma.contracts.count({
         where: {
+          ...whereClause,
+
           contract_address: {
             startsWith: searchInput,
           },
@@ -1700,6 +1714,8 @@ async function countResultsByType(
 
       const countEvidence = await prisma.evidences.count({
         where: {
+          ...whereClause,
+
           OR: [
             {evidence_id: {startsWith: searchInput}},
             {contract_address: {startsWith: searchInput}},
@@ -1709,6 +1725,8 @@ async function countResultsByType(
 
       const countRedFlag = await prisma.red_flags.count({
         where: {
+          ...whereClause,
+
           related_addresses: {
             hasSome: [`${searchInput}`],
           },
@@ -1717,6 +1735,8 @@ async function countResultsByType(
 
       const countAddress = await prisma.addresses.count({
         where: {
+          ...whereClause,
+
           address: {
             startsWith: searchInput,
           },
@@ -1725,6 +1745,8 @@ async function countResultsByType(
 
       const countBlacklist = await prisma.public_tags.count({
         where: {
+          ...whereClause,
+
           target: {
             startsWith: searchInput,
           },

--- a/src/pages/api/v1/app/search.ts
+++ b/src/pages/api/v1/app/search.ts
@@ -815,9 +815,6 @@ async function searchByType(
   end_date?: number,
   searchId?: number
 ): Promise<ISearchResult[]> {
-  // Function to perform the search based on type and return the formatted results
-  // Implement search logic similar to the original handler but more modular and efficient
-  // Return an array of ISearchResult based on the search type and input
   const resultData: ISearchResult[] = [];
   let stability = StabilityLevel.LOW;
   const whereClause = {
@@ -1587,32 +1584,28 @@ async function countResultsByType(
   end_date?: number,
   searchId?: number
 ): Promise<number> {
-  // Function to count the results based on type and input without actually retrieving all data
-  // Use similar logic to searchByType but for counting
-  // Return the count as a number
   const whereClause = {
     ...(start_date && end_date ? {created_timestamp: {gte: start_date, lte: end_date}} : {}),
   };
 
   switch (type) {
     case SearchType.BLOCK:
-      // Count blocks matching the search input
-      // const searchId = isValid64BitInteger(searchInput) ? parseInt(searchInput, 10) : undefined;
+      // Info: Count blocks matching the search input (20240306 - Shirley)
+      if (!!searchId) {
+        const blocksCount = await prisma.blocks.count({
+          where: {
+            ...whereClause,
+            number: searchId,
+          },
+        });
 
-      const blocksCount = await prisma.blocks.count({
-        where: {
-          ...whereClause,
-          number: searchId,
-        },
-      });
-
-      // eslint-disable-next-line no-console
-      console.log('blockCount', blocksCount);
-      return blocksCount;
-
+        return blocksCount;
+      } else {
+        return 0;
+      }
       break;
     case SearchType.TRANSACTION:
-      // Count transactions matching the search input
+      // Info: Count transactions matching the search input (20240306 - Shirley)
       const transactionsCount = await prisma.transactions.count({
         where: {
           ...whereClause,
@@ -1624,7 +1617,7 @@ async function countResultsByType(
       return transactionsCount;
       break;
     case SearchType.CONTRACT:
-      // Count contracts matching the search input
+      // Info: Count contracts matching the search input (20240306 - Shirley)
       const contractsCount = await prisma.contracts.count({
         where: {
           ...whereClause,
@@ -1636,7 +1629,7 @@ async function countResultsByType(
       return contractsCount;
       break;
     case SearchType.EVIDENCE:
-      // Count evidences matching the search input
+      // Info: Count evidences matching the search input (20240306 - Shirley)
       const evidencesCount = await prisma.evidences.count({
         where: {
           ...whereClause,
@@ -1649,7 +1642,7 @@ async function countResultsByType(
       return evidencesCount;
       break;
     case SearchType.RED_FLAG:
-      // Count red flags matching the search input
+      // Info: Count red flags matching the search input (20240306 - Shirley)
       const redFlagsCount = await prisma.red_flags.count({
         where: {
           ...whereClause,
@@ -1661,7 +1654,7 @@ async function countResultsByType(
       return redFlagsCount;
       break;
     case SearchType.ADDRESS:
-      // Count addresses matching the search input
+      // Info: Count addresses matching the search input (20240306 - Shirley)
       const addressesCount = await prisma.addresses.count({
         where: {
           ...whereClause,
@@ -1673,7 +1666,7 @@ async function countResultsByType(
       return addressesCount;
       break;
     case SearchType.BLACKLIST:
-      // Count blacklisted items matching the search input
+      // Info: Count blacklisted items matching the search input (20240306 - Shirley)
       const blacklistedAddressesCount = await prisma.public_tags.count({
         where: {
           ...whereClause,
@@ -1686,12 +1679,18 @@ async function countResultsByType(
       return blacklistedAddressesCount;
       break;
     default:
-      // Count all types matching the search input
-      const countBlock = await prisma.blocks.count({
-        where: {
-          number: searchId,
-        },
-      });
+      // Info: Count all types matching the search input (20240306 - Shirley)
+      let countBlock = 0;
+      if (!!searchId) {
+        countBlock = await prisma.blocks.count({
+          where: {
+            ...whereClause,
+            number: searchId,
+          },
+        });
+      } else {
+        countBlock = 0;
+      }
 
       const countTx = await prisma.transactions.count({
         where: {
@@ -1754,15 +1753,41 @@ async function countResultsByType(
         },
       });
 
-      return (
+      const totalCount =
         countBlock +
         countTx +
         countContract +
         countEvidence +
         countRedFlag +
         countAddress +
+        countBlacklist;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        'parameters:',
+        'searchInput',
+        searchInput,
+        'searchId',
+        searchId,
+        'totalCount',
+        totalCount,
+        'countBlock',
+        countBlock,
+        'countTx',
+        countTx,
+        'countContract',
+        countContract,
+        'countEvidence',
+        countEvidence,
+        'countRedFlag',
+        countRedFlag,
+        'countAddress',
+        countAddress,
+        'countBlacklist',
         countBlacklist
       );
+
+      return totalCount;
 
       break;
   }

--- a/src/pages/api/v1/app/search.ts
+++ b/src/pages/api/v1/app/search.ts
@@ -1,29 +1,1211 @@
 // 003 - GET /app/search?search_input=${searchInput}
 
 import type {NextApiRequest, NextApiResponse} from 'next';
-import {assessBlockStability, isValid64BitInteger} from '../../../../lib/common';
+import {assessAddressRisk, assessBlockStability, isValid64BitInteger} from '../../../../lib/common';
 import {StabilityLevel} from '../../../../constants/stability_level';
-import {ISearchResult} from '../../../../interfaces/search_result';
-import {SearchType} from '../../../../constants/search_type';
+import {ISearchResult, ISearchResultData} from '../../../../interfaces/search_result';
+import {ISearchType, SearchType, isSearchType} from '../../../../constants/search_type';
 import {RiskLevel} from '../../../../constants/risk_level';
-import {RED_FLAG_CODE_WHEN_NULL, TAG_TYPE} from '../../../../constants/config';
+import {
+  DEFAULT_PAGE,
+  ITEM_PER_PAGE,
+  RED_FLAG_CODE_WHEN_NULL,
+  TAG_TYPE,
+} from '../../../../constants/config';
 import prisma from '../../../../../prisma/client';
 import {AddressType} from '../../../../interfaces/address_info';
 
 // Info: Array of ResponseDataItem (20240131 - Shirley)
-type ResponseData = ISearchResult[];
+type ResponseData = ISearchResultData;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
   const searchInput = req.query.search_input as string;
+  const order = (req.query.order as string)?.toLowerCase() === 'asc' ? 'asc' : 'desc';
+  const page = typeof req.query.page === 'string' ? parseInt(req.query.page, 10) : DEFAULT_PAGE;
+  const offset =
+    typeof req.query.offset === 'string' ? parseInt(req.query.offset, 10) : ITEM_PER_PAGE;
+  const start_date =
+    typeof req.query.start_date === 'string' && parseInt(req.query.start_date, 10) > 0
+      ? parseInt(req.query.start_date, 10)
+      : undefined;
+  const end_date =
+    typeof req.query.end_date === 'string' && parseInt(req.query.end_date, 10) > 0
+      ? parseInt(req.query.end_date, 10)
+      : undefined;
+  const type =
+    typeof req.query.type === 'string' && isSearchType(req.query.type.toUpperCase())
+      ? req.query.type.toUpperCase()
+      : SearchType.ALL;
+
+  // eslint-disable-next-line no-console
+  console.log('all params', searchInput, order, page, offset, start_date, end_date, type);
 
   if (!searchInput) {
-    return res.status(400).json([]);
+    return res.status(400).json({} as ResponseData);
   }
 
-  const result: ISearchResult[] = [];
-  let stability = StabilityLevel.LOW;
+  const resultType = isSearchType(type) ? type : SearchType.ALL;
+  // let totalPage = 0;
+  // let count = 0;
+  const resultData: ISearchResult[] = [];
+
+  // let stability = StabilityLevel.LOW;
 
   try {
+    const take = offset;
+    const skip = page > 0 ? (page - 1) * offset : 0;
+    const searchId = isValid64BitInteger(searchInput) ? parseInt(searchInput, 10) : undefined;
+
+    const searchResult = await searchByType(
+      resultType,
+      searchInput,
+      take,
+      skip,
+      order,
+      start_date,
+      end_date,
+      searchId
+    );
+
+    const count = await countResultsByType(resultType, searchInput, start_date, end_date, searchId);
+    const totalPage = Math.ceil(count / offset);
+
+    // if (type && type !== SearchType.ALL) {
+    //   switch (type) {
+    //     case SearchType.BLOCK:
+    //       const searchId = isValid64BitInteger(searchInput) ? parseInt(searchInput, 10) : undefined;
+
+    //       // Info: calculate the stability for the targeted block (20240201 - Shirley)
+    //       const latestBlock = await prisma.blocks.findFirst({
+    //         orderBy: {
+    //           created_timestamp: 'desc',
+    //         },
+
+    //         select: {
+    //           id: true,
+    //           chain_id: true,
+    //           created_timestamp: true,
+    //           hash: true,
+    //           number: true,
+    //         },
+    //       });
+
+    //       if (!!searchId) {
+    //         const blocks = await prisma.blocks.findMany({
+    //           orderBy: {
+    //             created_timestamp: order,
+    //           },
+    //           where: {
+    //             number: searchId,
+    //           },
+    //           take,
+    //           skip,
+    //           select: {
+    //             id: true,
+    //             chain_id: true,
+    //             created_timestamp: true,
+    //             hash: true,
+    //             number: true,
+    //           },
+    //         });
+
+    //         blocks.forEach(item => {
+    //           if (latestBlock && latestBlock.number) {
+    //             const targetBlockId = item.number ? +item.number : 0;
+    //             stability = assessBlockStability(targetBlockId, latestBlock.number);
+    //           }
+
+    //           resultData.push({
+    //             type: SearchType.BLOCK,
+    //             data: {
+    //               id: `${item.number}`,
+    //               chainId: `${item.chain_id}`,
+    //               createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //               stability: stability,
+    //             },
+    //           });
+    //         });
+    //       }
+
+    //       count = resultData.length;
+    //       totalPage = Math.ceil(count / offset);
+    //       break;
+    //     case SearchType.TRANSACTION:
+    //       const transactions = await prisma.transactions.findMany({
+    //         where: {
+    //           hash: {
+    //             startsWith: searchInput,
+    //           },
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           chain_id: true,
+    //           created_timestamp: true,
+    //           hash: true,
+    //         },
+    //       });
+
+    //       transactions.forEach(item => {
+    //         resultData.push({
+    //           type: SearchType.TRANSACTION,
+    //           data: {
+    //             id: `${item.id}`,
+    //             chainId: `${item.chain_id}`,
+    //             createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //             hash: `${item.hash}`,
+    //           },
+    //         });
+    //       });
+    //       break;
+    //     case SearchType.CONTRACT:
+    //       const contracts = await prisma.contracts.findMany({
+    //         where: {
+    //           contract_address: {
+    //             startsWith: searchInput,
+    //           },
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           chain_id: true,
+    //           created_timestamp: true,
+    //           contract_address: true,
+    //         },
+    //       });
+
+    //       contracts.forEach(item => {
+    //         resultData.push({
+    //           type: SearchType.CONTRACT,
+    //           data: {
+    //             id: `${item.id}`,
+    //             chainId: `${item.chain_id}`,
+    //             createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //             contractAddress: `${item.contract_address}`,
+    //           },
+    //         });
+    //       });
+
+    //       count = resultData.length;
+    //       totalPage = Math.ceil(count / offset);
+    //       break;
+    //     case SearchType.EVIDENCE:
+    //       const evidences = await prisma.evidences.findMany({
+    //         where: {
+    //           OR: [
+    //             {evidence_id: {startsWith: searchInput}},
+    //             {contract_address: {startsWith: searchInput}},
+    //           ],
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           chain_id: true,
+    //           created_timestamp: true,
+    //           contract_address: true,
+    //           evidence_id: true,
+    //         },
+    //       });
+
+    //       evidences.forEach(item => {
+    //         resultData.push({
+    //           type: SearchType.EVIDENCE,
+    //           data: {
+    //             id: `${item.evidence_id}`,
+    //             chainId: `${item.chain_id}`,
+    //             createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //             evidenceAddress: `${item.contract_address}`,
+    //           },
+    //         });
+    //       });
+
+    //       count = resultData.length;
+    //       totalPage = Math.ceil(count / offset);
+
+    //       break;
+    //     case SearchType.RED_FLAG:
+    //       const redFlags = await prisma.red_flags.findMany({
+    //         where: {
+    //           related_addresses: {
+    //             hasSome: [`${searchInput}`],
+    //           },
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           chain_id: true,
+    //           created_timestamp: true,
+    //           related_addresses: true,
+    //           red_flag_type: true,
+    //         },
+    //       });
+
+    //       const redFlagCodes = await prisma.codes.findMany({
+    //         where: {
+    //           table_name: 'red_flags',
+    //         },
+    //         select: {
+    //           table_column: true,
+    //           value: true,
+    //           meaning: true,
+    //         },
+    //       });
+
+    //       const redFlagHistoryData = redFlags.map(redFlag => {
+    //         const relatedAddresses = redFlag.related_addresses.map(address => {
+    //           return {
+    //             id: `${address}`,
+    //             chainId: `${redFlag.chain_id}`,
+    //           };
+    //         });
+
+    //         const redFlagTypeCode = redFlag.red_flag_type
+    //           ? +redFlag.red_flag_type
+    //           : RED_FLAG_CODE_WHEN_NULL;
+
+    //         const redFlagType =
+    //           redFlagCodes.find(code => code.value === redFlagTypeCode)?.meaning ?? '';
+
+    //         return {
+    //           id: `${redFlag.id}`,
+    //           chainId: `${redFlag.chain_id}`,
+    //           createdTimestamp: redFlag.created_timestamp ? redFlag.created_timestamp : 0,
+    //           redFlagType: redFlagType,
+    //           interactedAddresses: relatedAddresses,
+    //         };
+    //       });
+
+    //       resultData.push(
+    //         ...redFlagHistoryData.map(item => ({
+    //           type: SearchType.RED_FLAG,
+    //           data: {
+    //             id: `${item.id}`,
+    //             chainId: `${item.chainId}`,
+    //             createdTimestamp: item.createdTimestamp,
+    //             redFlagType: item.redFlagType,
+    //             interactedAddresses: item.interactedAddresses,
+    //           },
+    //         }))
+    //       );
+
+    //       count = resultData.length;
+    //       totalPage = Math.ceil(count / offset);
+    //       break;
+    //     case SearchType.ADDRESS:
+    //       const addresses = await prisma.addresses.findMany({
+    //         where: {
+    //           address: {
+    //             startsWith: searchInput,
+    //           },
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           chain_id: true,
+    //           created_timestamp: true,
+    //           address: true,
+    //         },
+    //       });
+
+    //       addresses.forEach(item => {
+    //         resultData.push({
+    //           type: SearchType.ADDRESS,
+    //           data: {
+    //             id: `${item.id}`,
+    //             chainId: `${item.chain_id}`,
+    //             createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //             address: `${item.address}`,
+    //             flaggingCount: redFlags.length,
+    //             riskLevel: RiskLevel.LOW_RISK, // TODO: Risk level calculation (20240201 - Shirley)
+    //           },
+    //         });
+    //       });
+
+    //       count = resultData.length;
+    //       totalPage = Math.ceil(count / offset);
+    //       break;
+    //     case SearchType.BLACKLIST:
+    //       // Info: Find public tags with tag_type "9" matching search input (20240216 - Shirley)
+    //       const blacklistedAddresses = await prisma.public_tags.findMany({
+    //         where: {
+    //           target: {
+    //             startsWith: searchInput,
+    //           },
+    //           tag_type: TAG_TYPE.BLACKLIST,
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           name: true,
+    //           target: true,
+    //           target_type: true,
+    //           created_timestamp: true,
+    //         },
+    //       });
+
+    //       // const blacklistedAddressesCount = await prisma.public_tags.count({
+    //       //   where: {
+    //       //     target: {
+    //       //       startsWith: searchInput,
+    //       //     },
+    //       //     tag_type: TAG_TYPE.BLACKLIST,
+    //       //   },
+    //       // });
+
+    //       // const resultTotalPage = Math.ceil(blacklistedAddressesCount / offset);
+
+    //       const contractTargets = blacklistedAddresses
+    //         .filter(tag => tag.target_type === '0')
+    //         .map(tag => tag.target as string);
+    //       const addressTargets = blacklistedAddresses
+    //         .filter(tag => tag.target_type === '1')
+    //         .map(tag => tag.target as string);
+
+    //       const contractsChainIds = await prisma.contracts.findMany({
+    //         where: {
+    //           contract_address: {in: contractTargets},
+    //         },
+    //         select: {
+    //           contract_address: true,
+    //           chain_id: true,
+    //         },
+    //       });
+
+    //       const addressesChainIds = await prisma.addresses.findMany({
+    //         where: {
+    //           address: {in: addressTargets},
+    //         },
+    //         select: {
+    //           address: true,
+    //           chain_id: true,
+    //           latest_active_time: true,
+    //         },
+    //       });
+
+    //       const chainIdMap = new Map();
+    //       const lastActiveTimeMap = new Map();
+    //       const addressTypeMap = new Map();
+
+    //       addressesChainIds.forEach(address => {
+    //         lastActiveTimeMap.set(address.address, address.latest_active_time);
+    //         addressTypeMap.set(address.address, AddressType.ADDRESS);
+    //       });
+
+    //       contractsChainIds.forEach(contract => {
+    //         chainIdMap.set(contract.contract_address, contract.chain_id);
+    //         addressTypeMap.set(contract.contract_address, AddressType.CONTRACT);
+    //       });
+    //       addressesChainIds.forEach(address => chainIdMap.set(address.address, address.chain_id));
+
+    //       blacklistedAddresses.forEach(item => {
+    //         const chainId = chainIdMap.get(item.target) ?? '';
+    //         const addressType = addressTypeMap.get(item.target) ?? AddressType.ADDRESS;
+    //         const rs = {
+    //           type: SearchType.BLACKLIST,
+    //           data: {
+    //             id: `${item?.id}`,
+    //             chainId: `${chainId}`,
+    //             createdTimestamp: item?.created_timestamp ? item?.created_timestamp : 0,
+    //             address: `${item.target}`,
+    //             targetType: `${addressType}`,
+    //             latestActiveTime: lastActiveTimeMap.get(item.target) ?? 0,
+    //             tagName: `${item.name}`,
+    //           },
+    //         };
+
+    //         resultData.push({
+    //           type: SearchType.BLACKLIST,
+    //           data: {
+    //             id: `${item?.id}`,
+    //             chainId: `${chainId}`,
+    //             createdTimestamp: item?.created_timestamp ? item?.created_timestamp : 0,
+    //             address: `${item.target}`,
+    //             targetType: `${addressType}`,
+    //             latestActiveTime: lastActiveTimeMap.get(item.target) ?? 0,
+    //             tagName: `${item.name}`,
+    //           },
+    //         });
+    //       });
+
+    //       count = resultData.length;
+    //       totalPage = Math.ceil(count / offset);
+    //       break;
+    //     default:
+    //       break;
+    //   }
+    // } else {
+    //   const searchId = isValid64BitInteger(searchInput) ? parseInt(searchInput, 10) : undefined;
+
+    //   // Info: calculate the stability for the targeted block (20240201 - Shirley)
+    //   const latestBlock = await prisma.blocks.findFirst({
+    //     orderBy: {
+    //       created_timestamp: 'desc',
+    //     },
+    //     select: {
+    //       id: true,
+    //       chain_id: true,
+    //       created_timestamp: true,
+    //       hash: true,
+    //       number: true,
+    //     },
+    //   });
+
+    //   if (!!searchId && resultData.length < offset) {
+    //     const blocks = await prisma.blocks.findMany({
+    //       orderBy: {
+    //         created_timestamp: order,
+    //       },
+    //       where: {
+    //         number: searchId,
+    //       },
+    //       take,
+    //       skip,
+    //       select: {
+    //         id: true,
+    //         chain_id: true,
+    //         created_timestamp: true,
+    //         hash: true,
+    //         number: true,
+    //       },
+    //     });
+
+    //     blocks.forEach(item => {
+    //       if (latestBlock && latestBlock.number) {
+    //         const targetBlockId = item.number ? +item.number : 0;
+    //         stability = assessBlockStability(targetBlockId, latestBlock.number);
+    //       }
+
+    //       resultData.push({
+    //         type: SearchType.BLOCK,
+    //         data: {
+    //           id: `${item.number}`,
+    //           chainId: `${item.chain_id}`,
+    //           createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //           stability: stability,
+    //         },
+    //       });
+    //     });
+    //   }
+
+    //   if (resultData.length < offset) {
+    //     const transactions = await prisma.transactions.findMany({
+    //       where: {
+    //         hash: {
+    //           startsWith: searchInput,
+    //         },
+    //       },
+    //       take,
+    //       skip,
+    //       select: {
+    //         id: true,
+    //         chain_id: true,
+    //         created_timestamp: true,
+    //         hash: true,
+    //       },
+    //     });
+
+    //     transactions.forEach(item => {
+    //       resultData.push({
+    //         type: SearchType.TRANSACTION,
+    //         data: {
+    //           id: `${item.id}`,
+    //           chainId: `${item.chain_id}`,
+    //           createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //           hash: `${item.hash}`,
+    //         },
+    //       });
+    //     });
+    //   }
+
+    //   if (resultData.length < offset) {
+    //     const contracts = await prisma.contracts.findMany({
+    //       where: {
+    //         contract_address: {
+    //           startsWith: searchInput,
+    //         },
+    //       },
+    //       take,
+    //       skip,
+    //       select: {
+    //         id: true,
+    //         chain_id: true,
+    //         created_timestamp: true,
+    //         contract_address: true,
+    //       },
+    //     });
+
+    //     contracts.forEach(item => {
+    //       resultData.push({
+    //         type: SearchType.CONTRACT,
+    //         data: {
+    //           id: `${item.id}`,
+    //           chainId: `${item.chain_id}`,
+    //           createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //           contractAddress: `${item.contract_address}`,
+    //         },
+    //       });
+    //     });
+    //   }
+
+    //   if (resultData.length < offset) {
+    //     const evidences = await prisma.evidences.findMany({
+    //       where: {
+    //         OR: [
+    //           {evidence_id: {startsWith: searchInput}},
+    //           {contract_address: {startsWith: searchInput}},
+    //         ],
+    //       },
+    //       take,
+    //       skip,
+    //       select: {
+    //         id: true,
+    //         chain_id: true,
+    //         created_timestamp: true,
+    //         contract_address: true,
+    //         evidence_id: true,
+    //       },
+    //     });
+
+    //     evidences.forEach(item => {
+    //       resultData.push({
+    //         type: SearchType.EVIDENCE,
+    //         data: {
+    //           id: `${item.evidence_id}`,
+    //           chainId: `${item.chain_id}`,
+    //           createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //           evidenceAddress: `${item.contract_address}`,
+    //         },
+    //       });
+    //     });
+    //   }
+
+    //   if (resultData.length < offset) {
+    //     const redFlags = await prisma.red_flags.findMany({
+    //       where: {
+    //         related_addresses: {
+    //           hasSome: [`${searchInput}`],
+    //         },
+    //       },
+    //       take,
+    //       skip,
+    //       select: {
+    //         id: true,
+    //         chain_id: true,
+    //         created_timestamp: true,
+    //         related_addresses: true,
+    //         red_flag_type: true,
+    //       },
+    //     });
+
+    //     const redFlagCodes = await prisma.codes.findMany({
+    //       where: {
+    //         table_name: 'red_flags',
+    //       },
+    //       select: {
+    //         table_column: true,
+    //         value: true,
+    //         meaning: true,
+    //       },
+    //     });
+
+    //     const redFlagHistoryData = redFlags.map(redFlag => {
+    //       const relatedAddresses = redFlag.related_addresses.map(address => {
+    //         return {
+    //           id: `${address}`,
+    //           chainId: `${redFlag.chain_id}`,
+    //         };
+    //       });
+
+    //       const redFlagTypeCode = redFlag.red_flag_type
+    //         ? +redFlag.red_flag_type
+    //         : RED_FLAG_CODE_WHEN_NULL;
+
+    //       const redFlagType =
+    //         redFlagCodes.find(code => code.value === redFlagTypeCode)?.meaning ?? '';
+
+    //       return {
+    //         id: `${redFlag.id}`,
+    //         chainId: `${redFlag.chain_id}`,
+    //         createdTimestamp: redFlag.created_timestamp ? redFlag.created_timestamp : 0,
+    //         redFlagType: redFlagType,
+    //         interactedAddresses: relatedAddresses,
+    //       };
+    //     });
+
+    //     resultData.push(
+    //       ...redFlagHistoryData.map(item => ({
+    //         type: SearchType.RED_FLAG,
+    //         data: {
+    //           id: `${item.id}`,
+    //           chainId: `${item.chainId}`,
+    //           createdTimestamp: item.createdTimestamp,
+    //           redFlagType: item.redFlagType,
+    //           interactedAddresses: item.interactedAddresses,
+    //         },
+    //       }))
+    //     );
+
+    //     //   redFlags.forEach(item => {
+    //     //     if (item.related_addresses.some(address => address.startsWith(searchInput))) {
+    //     //       resultData.push({
+    //     //         type: SearchType.RED_FLAG,
+    //     //         data: {
+    //     //           id: `${item.id}`,
+    //     //           chainId: `${item.chain_id}`,
+    //     //           createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //     //           redFlagType: `${item.red_flag_type}`,
+    //     //           interactedAddresses: item.related_addresses.map(address => {
+    //     //             return {
+    //     //               id: `${address}`, // TODO: addressID or address? (20240201 - Shirley)
+    //     //               chainId: `${item.chain_id}`,
+    //     //             };
+    //     //           }),
+    //     //         },
+    //     //       });
+    //     //     }
+    //     //   });
+    //     // }
+
+    //     if (resultData.length < offset) {
+    //       const addresses = await prisma.addresses.findMany({
+    //         where: {
+    //           address: {
+    //             startsWith: searchInput,
+    //           },
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           chain_id: true,
+    //           created_timestamp: true,
+    //           address: true,
+    //         },
+    //       });
+
+    //       addresses.forEach(item => {
+    //         resultData.push({
+    //           type: SearchType.ADDRESS,
+    //           data: {
+    //             id: `${item.id}`,
+    //             chainId: `${item.chain_id}`,
+    //             createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+    //             address: `${item.address}`,
+    //             flaggingCount: redFlags.length,
+    //             riskLevel: RiskLevel.LOW_RISK, // TODO: Risk level calculation (20240201 - Shirley)
+    //           },
+    //         });
+    //       });
+
+    //       // Info: Find public tags with tag_type "9" matching search input (20240216 - Shirley)
+    //       const blacklistedAddresses = await prisma.public_tags.findMany({
+    //         where: {
+    //           target: {
+    //             startsWith: searchInput,
+    //           },
+    //           tag_type: TAG_TYPE.BLACKLIST,
+    //         },
+    //         take,
+    //         skip,
+    //         select: {
+    //           id: true,
+    //           name: true,
+    //           target: true,
+    //           target_type: true,
+    //           created_timestamp: true,
+    //         },
+    //       });
+
+    //       const contractTargets = blacklistedAddresses
+    //         .filter(tag => tag.target_type === '0')
+    //         .map(tag => tag.target as string);
+    //       const addressTargets = blacklistedAddresses
+    //         .filter(tag => tag.target_type === '1')
+    //         .map(tag => tag.target as string);
+
+    //       const contractsChainIds = await prisma.contracts.findMany({
+    //         where: {
+    //           contract_address: {in: contractTargets},
+    //         },
+    //         select: {
+    //           contract_address: true,
+    //           chain_id: true,
+    //         },
+    //       });
+
+    //       const addressesChainIds = await prisma.addresses.findMany({
+    //         where: {
+    //           address: {in: addressTargets},
+    //         },
+    //         select: {
+    //           address: true,
+    //           chain_id: true,
+    //           latest_active_time: true,
+    //         },
+    //       });
+
+    //       const chainIdMap = new Map();
+    //       const lastActiveTimeMap = new Map();
+    //       const addressTypeMap = new Map();
+
+    //       addressesChainIds.forEach(address => {
+    //         lastActiveTimeMap.set(address.address, address.latest_active_time);
+    //         addressTypeMap.set(address.address, AddressType.ADDRESS);
+    //       });
+
+    //       contractsChainIds.forEach(contract => {
+    //         chainIdMap.set(contract.contract_address, contract.chain_id);
+    //         addressTypeMap.set(contract.contract_address, AddressType.CONTRACT);
+    //       });
+    //       addressesChainIds.forEach(address => chainIdMap.set(address.address, address.chain_id));
+
+    //       blacklistedAddresses.forEach(item => {
+    //         const chainId = chainIdMap.get(item.target) ?? '';
+    //         const addressType = addressTypeMap.get(item.target) ?? AddressType.ADDRESS;
+
+    //         resultData.push({
+    //           type: SearchType.BLACKLIST,
+    //           data: {
+    //             id: `${item?.id}`,
+    //             chainId: `${chainId}`,
+    //             createdTimestamp: item?.created_timestamp ? item?.created_timestamp : 0,
+    //             address: `${item.target}`,
+    //             targetType: `${addressType}`,
+    //             latestActiveTime: lastActiveTimeMap.get(item.target) ?? 0,
+    //             tagName: `${item.name}`,
+    //           },
+    //         });
+    //       });
+    //     }
+    //   }
+
+    //   count = resultData.length;
+    //   totalPage = Math.ceil(count / offset);
+    // }
+
+    const result: ISearchResultData = {
+      type: resultType,
+      count: count,
+      totalPage: totalPage,
+      data: searchResult,
+    };
+
+    res.status(200).json(result);
+  } catch (error) {
+    // Info: (20240130 - Shirley) Request error
+    // eslint-disable-next-line no-console
+    console.error('search result request', error);
+    res.status(500).json({} as ResponseData);
+  }
+}
+
+async function searchByType(
+  type: ISearchType,
+  searchInput: string,
+  take: number,
+  skip: number,
+  order: 'asc' | 'desc',
+  start_date?: number,
+  end_date?: number,
+  searchId?: number
+): Promise<ISearchResult[]> {
+  // Function to perform the search based on type and return the formatted results
+  // Implement search logic similar to the original handler but more modular and efficient
+  // Return an array of ISearchResult based on the search type and input
+  const resultData: ISearchResult[] = [];
+  let stability = StabilityLevel.LOW;
+  const whereClause = {
+    ...(start_date && end_date ? {created_timestamp: {gte: start_date, lte: end_date}} : {}),
+  };
+
+  if (type && type !== SearchType.ALL) {
+    switch (type) {
+      case SearchType.BLOCK:
+        // const searchId = isValid64BitInteger(searchInput) ? parseInt(searchInput, 10) : undefined;
+
+        // Info: calculate the stability for the targeted block (20240201 - Shirley)
+        const latestBlock = await prisma.blocks.findFirst({
+          orderBy: {
+            created_timestamp: 'desc',
+          },
+          select: {
+            id: true,
+            chain_id: true,
+            created_timestamp: true,
+            hash: true,
+            number: true,
+          },
+        });
+
+        if (!!searchId) {
+          const blocks = await prisma.blocks.findMany({
+            orderBy: {
+              created_timestamp: order,
+            },
+            where: {
+              ...whereClause,
+              number: searchId,
+            },
+            take,
+            skip,
+            select: {
+              id: true,
+              chain_id: true,
+              created_timestamp: true,
+              hash: true,
+              number: true,
+            },
+          });
+
+          blocks.forEach(item => {
+            if (latestBlock && latestBlock.number) {
+              const targetBlockId = item.number ? +item.number : 0;
+              stability = assessBlockStability(targetBlockId, latestBlock.number);
+            }
+
+            resultData.push({
+              type: SearchType.BLOCK,
+              data: {
+                id: `${item.number}`,
+                chainId: `${item.chain_id}`,
+                createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+                stability: stability,
+              },
+            });
+          });
+        }
+
+        break;
+      case SearchType.TRANSACTION:
+        const transactions = await prisma.transactions.findMany({
+          where: {
+            ...whereClause,
+
+            hash: {
+              startsWith: searchInput,
+            },
+          },
+          take,
+          skip,
+          orderBy: {
+            created_timestamp: order,
+          },
+          select: {
+            id: true,
+            chain_id: true,
+            created_timestamp: true,
+            hash: true,
+          },
+        });
+
+        transactions.forEach(item => {
+          resultData.push({
+            type: SearchType.TRANSACTION,
+            data: {
+              id: `${item.id}`,
+              chainId: `${item.chain_id}`,
+              createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+              hash: `${item.hash}`,
+            },
+          });
+        });
+        break;
+      case SearchType.CONTRACT:
+        const contracts = await prisma.contracts.findMany({
+          where: {
+            ...whereClause,
+
+            contract_address: {
+              startsWith: searchInput,
+            },
+          },
+          take,
+          skip,
+          orderBy: {
+            created_timestamp: order,
+          },
+          select: {
+            id: true,
+            chain_id: true,
+            created_timestamp: true,
+            contract_address: true,
+          },
+        });
+
+        contracts.forEach(item => {
+          resultData.push({
+            type: SearchType.CONTRACT,
+            data: {
+              id: `${item.id}`,
+              chainId: `${item.chain_id}`,
+              createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+              contractAddress: `${item.contract_address}`,
+            },
+          });
+        });
+
+        break;
+      case SearchType.EVIDENCE:
+        const evidences = await prisma.evidences.findMany({
+          where: {
+            ...whereClause,
+
+            OR: [
+              {evidence_id: {startsWith: searchInput}},
+              {contract_address: {startsWith: searchInput}},
+            ],
+          },
+          take,
+          skip,
+          orderBy: {
+            created_timestamp: order,
+          },
+          select: {
+            id: true,
+            chain_id: true,
+            created_timestamp: true,
+            contract_address: true,
+            evidence_id: true,
+          },
+        });
+
+        evidences.forEach(item => {
+          resultData.push({
+            type: SearchType.EVIDENCE,
+            data: {
+              id: `${item.evidence_id}`,
+              chainId: `${item.chain_id}`,
+              createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+              evidenceAddress: `${item.contract_address}`,
+            },
+          });
+        });
+
+        break;
+      case SearchType.RED_FLAG:
+        const redFlags = await prisma.red_flags.findMany({
+          where: {
+            ...whereClause,
+
+            related_addresses: {
+              hasSome: [`${searchInput}`],
+            },
+          },
+          take,
+          skip,
+          orderBy: {
+            created_timestamp: order,
+          },
+          select: {
+            id: true,
+            chain_id: true,
+            created_timestamp: true,
+            related_addresses: true,
+            red_flag_type: true,
+          },
+        });
+
+        const redFlagCodes = await prisma.codes.findMany({
+          where: {
+            table_name: 'red_flags',
+          },
+          select: {
+            table_column: true,
+            value: true,
+            meaning: true,
+          },
+        });
+
+        const redFlagHistoryData = redFlags.map(redFlag => {
+          const relatedAddresses = redFlag.related_addresses.map(address => {
+            return {
+              id: `${address}`,
+              chainId: `${redFlag.chain_id}`,
+            };
+          });
+
+          const redFlagTypeCode = redFlag.red_flag_type
+            ? +redFlag.red_flag_type
+            : RED_FLAG_CODE_WHEN_NULL;
+
+          const redFlagType =
+            redFlagCodes.find(code => code.value === redFlagTypeCode)?.meaning ?? '';
+
+          return {
+            id: `${redFlag.id}`,
+            chainId: `${redFlag.chain_id}`,
+            createdTimestamp: redFlag.created_timestamp ? redFlag.created_timestamp : 0,
+            redFlagType: redFlagType,
+            interactedAddresses: relatedAddresses,
+          };
+        });
+
+        resultData.push(
+          ...redFlagHistoryData.map(item => ({
+            type: SearchType.RED_FLAG,
+            data: {
+              id: `${item.id}`,
+              chainId: `${item.chainId}`,
+              createdTimestamp: item.createdTimestamp,
+              redFlagType: item.redFlagType,
+              interactedAddresses: item.interactedAddresses,
+            },
+          }))
+        );
+
+        break;
+      case SearchType.ADDRESS:
+        const flaggingRecords = await prisma.red_flags.findMany({
+          where: {related_addresses: {hasSome: [searchInput]}},
+          select: {id: true, red_flag_type: true},
+        });
+
+        // eslint-disable-next-line no-console
+        console.log('flaggingRecords', flaggingRecords);
+
+        // const flaggingRecords1 = await prisma.red_flags.count({
+        //   where: {related_addresses: {hasSome: [searchInput]}},
+        //   select: {id: true, red_flag_type: true},
+        // });
+
+        const riskRecords = flaggingRecords.length;
+        const riskLevel = assessAddressRisk(riskRecords);
+
+        const addresses = await prisma.addresses.findMany({
+          where: {
+            ...whereClause,
+            address: {
+              startsWith: searchInput,
+            },
+          },
+          take,
+          skip,
+          orderBy: {
+            created_timestamp: order,
+          },
+          select: {
+            id: true,
+            chain_id: true,
+            created_timestamp: true,
+            address: true,
+          },
+        });
+
+        // eslint-disable-next-line no-console
+        console.log('addresses', addresses);
+
+        addresses.forEach(item => {
+          resultData.push({
+            type: SearchType.ADDRESS,
+            data: {
+              id: `${item.id}`,
+              chainId: `${item.chain_id}`,
+              createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+              address: `${item.address}`,
+              flaggingCount: riskRecords,
+              riskLevel: riskLevel, // TODO: Risk level calculation (20240201 - Shirley)
+            },
+          });
+        });
+
+        break;
+      case SearchType.BLACKLIST:
+        // Info: Find public tags with tag_type "9" matching search input (20240216 - Shirley)
+        const blacklistedAddresses = await prisma.public_tags.findMany({
+          where: {
+            ...whereClause,
+
+            target: {
+              startsWith: searchInput,
+            },
+            tag_type: TAG_TYPE.BLACKLIST,
+          },
+          take,
+          skip,
+          orderBy: {
+            created_timestamp: order,
+          },
+          select: {
+            id: true,
+            name: true,
+            target: true,
+            target_type: true,
+            created_timestamp: true,
+          },
+        });
+
+        const contractTargets = blacklistedAddresses
+          .filter(tag => tag.target_type === '0')
+          .map(tag => tag.target as string);
+        const addressTargets = blacklistedAddresses
+          .filter(tag => tag.target_type === '1')
+          .map(tag => tag.target as string);
+
+        const contractsChainIds = await prisma.contracts.findMany({
+          where: {
+            contract_address: {in: contractTargets},
+          },
+          select: {
+            contract_address: true,
+            chain_id: true,
+          },
+        });
+
+        const addressesChainIds = await prisma.addresses.findMany({
+          where: {
+            address: {in: addressTargets},
+          },
+          select: {
+            address: true,
+            chain_id: true,
+            latest_active_time: true,
+          },
+        });
+
+        const chainIdMap = new Map();
+        const lastActiveTimeMap = new Map();
+        const addressTypeMap = new Map();
+
+        addressesChainIds.forEach(address => {
+          lastActiveTimeMap.set(address.address, address.latest_active_time);
+          addressTypeMap.set(address.address, AddressType.ADDRESS);
+        });
+
+        contractsChainIds.forEach(contract => {
+          chainIdMap.set(contract.contract_address, contract.chain_id);
+          addressTypeMap.set(contract.contract_address, AddressType.CONTRACT);
+        });
+        addressesChainIds.forEach(address => chainIdMap.set(address.address, address.chain_id));
+
+        blacklistedAddresses.forEach(item => {
+          const chainId = chainIdMap.get(item.target) ?? '';
+          const addressType = addressTypeMap.get(item.target) ?? AddressType.ADDRESS;
+
+          resultData.push({
+            type: SearchType.BLACKLIST,
+            data: {
+              id: `${item?.id}`,
+              chainId: `${chainId}`,
+              createdTimestamp: item?.created_timestamp ? item?.created_timestamp : 0,
+              address: `${item.target}`,
+              targetType: `${addressType}`,
+              latestActiveTime: lastActiveTimeMap.get(item.target) ?? 0,
+              tagName: `${item.name}`,
+            },
+          });
+        });
+
+        break;
+      default:
+        break;
+    }
+  } else {
     const searchId = isValid64BitInteger(searchInput) ? parseInt(searchInput, 10) : undefined;
 
     // Info: calculate the stability for the targeted block (20240201 - Shirley)
@@ -40,14 +1222,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       },
     });
 
-    if (!!searchId) {
+    if (!!searchId && resultData.length < take) {
       const blocks = await prisma.blocks.findMany({
         orderBy: {
-          created_timestamp: 'desc',
+          created_timestamp: order,
         },
         where: {
+          ...whereClause,
+
           number: searchId,
         },
+        take,
+        skip,
         select: {
           id: true,
           chain_id: true,
@@ -63,7 +1249,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
           stability = assessBlockStability(targetBlockId, latestBlock.number);
         }
 
-        result.push({
+        resultData.push({
           type: SearchType.BLOCK,
           data: {
             id: `${item.number}`,
@@ -75,291 +1261,487 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       });
     }
 
-    const transactions = await prisma.transactions.findMany({
-      where: {
-        hash: {
-          startsWith: searchInput,
-        },
-      },
-      select: {
-        id: true,
-        chain_id: true,
-        created_timestamp: true,
-        hash: true,
-      },
-    });
+    if (resultData.length < take) {
+      const transactions = await prisma.transactions.findMany({
+        where: {
+          ...whereClause,
 
-    transactions.forEach(item => {
-      result.push({
-        type: SearchType.TRANSACTION,
-        data: {
-          id: `${item.id}`,
-          chainId: `${item.chain_id}`,
-          createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
-          hash: `${item.hash}`,
+          hash: {
+            startsWith: searchInput,
+          },
+        },
+        take,
+        skip,
+        orderBy: [{created_timestamp: order}, {id: order}],
+        select: {
+          id: true,
+          chain_id: true,
+          created_timestamp: true,
+          hash: true,
         },
       });
-    });
 
-    const contracts = await prisma.contracts.findMany({
-      where: {
-        contract_address: {
-          startsWith: searchInput,
+      transactions.forEach(item => {
+        resultData.push({
+          type: SearchType.TRANSACTION,
+          data: {
+            id: `${item.id}`,
+            chainId: `${item.chain_id}`,
+            createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+            hash: `${item.hash}`,
+          },
+        });
+      });
+    }
+
+    if (resultData.length < take) {
+      const contracts = await prisma.contracts.findMany({
+        where: {
+          ...whereClause,
+
+          contract_address: {
+            startsWith: searchInput,
+          },
         },
-      },
-      select: {
-        id: true,
-        chain_id: true,
-        created_timestamp: true,
-        contract_address: true,
-      },
-    });
-
-    contracts.forEach(item => {
-      result.push({
-        type: SearchType.CONTRACT,
-        data: {
-          id: `${item.id}`,
-          chainId: `${item.chain_id}`,
-          createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
-          contractAddress: `${item.contract_address}`,
+        take,
+        skip,
+        orderBy: [{created_timestamp: order}],
+        select: {
+          id: true,
+          chain_id: true,
+          created_timestamp: true,
+          contract_address: true,
         },
       });
-    });
 
-    const evidences = await prisma.evidences.findMany({
-      where: {
-        OR: [
-          {evidence_id: {startsWith: searchInput}},
-          {contract_address: {startsWith: searchInput}},
-        ],
-      },
-      select: {
-        id: true,
-        chain_id: true,
-        created_timestamp: true,
-        contract_address: true,
-        evidence_id: true,
-      },
-    });
+      contracts.forEach(item => {
+        resultData.push({
+          type: SearchType.CONTRACT,
+          data: {
+            id: `${item.id}`,
+            chainId: `${item.chain_id}`,
+            createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+            contractAddress: `${item.contract_address}`,
+          },
+        });
+      });
+    }
 
-    evidences.forEach(item => {
-      result.push({
-        type: SearchType.EVIDENCE,
-        data: {
-          id: `${item.evidence_id}`,
-          chainId: `${item.chain_id}`,
-          createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
-          evidenceAddress: `${item.contract_address}`,
+    if (resultData.length < take) {
+      const evidences = await prisma.evidences.findMany({
+        where: {
+          ...whereClause,
+
+          OR: [
+            {evidence_id: {startsWith: searchInput}},
+            {contract_address: {startsWith: searchInput}},
+          ],
+        },
+        take,
+        skip,
+        orderBy: [{created_timestamp: order}],
+
+        select: {
+          id: true,
+          chain_id: true,
+          created_timestamp: true,
+          contract_address: true,
+          evidence_id: true,
         },
       });
-    });
 
-    const redFlags = await prisma.red_flags.findMany({
-      where: {
-        related_addresses: {
-          hasSome: [`${searchInput}`],
+      evidences.forEach(item => {
+        resultData.push({
+          type: SearchType.EVIDENCE,
+          data: {
+            id: `${item.evidence_id}`,
+            chainId: `${item.chain_id}`,
+            createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+            evidenceAddress: `${item.contract_address}`,
+          },
+        });
+      });
+    }
+
+    if (resultData.length < take) {
+      const redFlags = await prisma.red_flags.findMany({
+        where: {
+          ...whereClause,
+
+          related_addresses: {
+            hasSome: [`${searchInput}`],
+          },
         },
-      },
-      select: {
-        id: true,
-        chain_id: true,
-        created_timestamp: true,
-        related_addresses: true,
-        red_flag_type: true,
-      },
-    });
+        take,
+        skip,
+        orderBy: [{created_timestamp: order}],
 
-    const redFlagCodes = await prisma.codes.findMany({
-      where: {
-        table_name: 'red_flags',
-      },
-      select: {
-        table_column: true,
-        value: true,
-        meaning: true,
-      },
-    });
+        select: {
+          id: true,
+          chain_id: true,
+          created_timestamp: true,
+          related_addresses: true,
+          red_flag_type: true,
+        },
+      });
 
-    const redFlagHistoryData = redFlags.map(redFlag => {
-      const relatedAddresses = redFlag.related_addresses.map(address => {
+      const redFlagCodes = await prisma.codes.findMany({
+        where: {
+          table_name: 'red_flags',
+        },
+        select: {
+          table_column: true,
+          value: true,
+          meaning: true,
+        },
+      });
+
+      const redFlagHistoryData = redFlags.map(redFlag => {
+        const relatedAddresses = redFlag.related_addresses.map(address => {
+          return {
+            id: `${address}`,
+            chainId: `${redFlag.chain_id}`,
+          };
+        });
+
+        const redFlagTypeCode = redFlag.red_flag_type
+          ? +redFlag.red_flag_type
+          : RED_FLAG_CODE_WHEN_NULL;
+
+        const redFlagType =
+          redFlagCodes.find(code => code.value === redFlagTypeCode)?.meaning ?? '';
+
         return {
-          id: `${address}`,
+          id: `${redFlag.id}`,
           chainId: `${redFlag.chain_id}`,
+          createdTimestamp: redFlag.created_timestamp ? redFlag.created_timestamp : 0,
+          redFlagType: redFlagType,
+          interactedAddresses: relatedAddresses,
         };
       });
 
-      const redFlagTypeCode = redFlag.red_flag_type
-        ? +redFlag.red_flag_type
-        : RED_FLAG_CODE_WHEN_NULL;
+      resultData.push(
+        ...redFlagHistoryData.map(item => ({
+          type: SearchType.RED_FLAG,
+          data: {
+            id: `${item.id}`,
+            chainId: `${item.chainId}`,
+            createdTimestamp: item.createdTimestamp,
+            redFlagType: item.redFlagType,
+            interactedAddresses: item.interactedAddresses,
+          },
+        }))
+      );
 
-      const redFlagType = redFlagCodes.find(code => code.value === redFlagTypeCode)?.meaning ?? '';
+      //   redFlags.forEach(item => {
+      //     if (item.related_addresses.some(address => address.startsWith(searchInput))) {
+      //       resultData.push({
+      //         type: SearchType.RED_FLAG,
+      //         data: {
+      //           id: `${item.id}`,
+      //           chainId: `${item.chain_id}`,
+      //           createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+      //           redFlagType: `${item.red_flag_type}`,
+      //           interactedAddresses: item.related_addresses.map(address => {
+      //             return {
+      //               id: `${address}`, // TODO: addressID or address? (20240201 - Shirley)
+      //               chainId: `${item.chain_id}`,
+      //             };
+      //           }),
+      //         },
+      //       });
+      //     }
+      //   });
+      // }
 
-      return {
-        id: `${redFlag.id}`,
-        chainId: `${redFlag.chain_id}`,
-        createdTimestamp: redFlag.created_timestamp ? redFlag.created_timestamp : 0,
-        redFlagType: redFlagType,
-        interactedAddresses: relatedAddresses,
-      };
-    });
+      if (resultData.length < take) {
+        const addresses = await prisma.addresses.findMany({
+          where: {
+            ...whereClause,
 
-    result.push(
-      ...redFlagHistoryData.map(item => ({
-        type: SearchType.RED_FLAG,
-        data: {
-          id: `${item.id}`,
-          chainId: `${item.chainId}`,
-          createdTimestamp: item.createdTimestamp,
-          redFlagType: item.redFlagType,
-          interactedAddresses: item.interactedAddresses,
-        },
-      }))
-    );
+            address: {
+              startsWith: searchInput,
+            },
+          },
+          take,
+          skip,
+          orderBy: [{created_timestamp: order}],
 
-    // redFlags.forEach(item => {
-    //   if (item.related_addresses.some(address => address.startsWith(searchInput))) {
-    //     result.push({
-    //       type: SearchType.RED_FLAG,
-    //       data: {
-    //         id: `${item.id}`,
-    //         chainId: `${item.chain_id}`,
-    //         createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
-    //         redFlagType: `${item.red_flag_type}`,
-    //         interactedAddresses: item.related_addresses.map(address => {
-    //           return {
-    //             id: `${address}`, // TODO: addressID or address? (20240201 - Shirley)
-    //             chainId: `${item.chain_id}`,
-    //           };
-    //         }),
-    //       },
-    //     });
-    //   }
-    // });
+          select: {
+            id: true,
+            chain_id: true,
+            created_timestamp: true,
+            address: true,
+          },
+        });
 
-    const addresses = await prisma.addresses.findMany({
-      where: {
-        address: {
-          startsWith: searchInput,
-        },
-      },
-      select: {
-        id: true,
-        chain_id: true,
-        created_timestamp: true,
-        address: true,
-      },
-    });
+        addresses.forEach(item => {
+          resultData.push({
+            type: SearchType.ADDRESS,
+            data: {
+              id: `${item.id}`,
+              chainId: `${item.chain_id}`,
+              createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
+              address: `${item.address}`,
+              flaggingCount: redFlags.length,
+              riskLevel: RiskLevel.LOW_RISK, // TODO: Risk level calculation (20240201 - Shirley)
+            },
+          });
+        });
 
-    addresses.forEach(item => {
-      result.push({
-        type: SearchType.ADDRESS,
-        data: {
-          id: `${item.id}`,
-          chainId: `${item.chain_id}`,
-          createdTimestamp: item.created_timestamp ? item.created_timestamp : 0,
-          address: `${item.address}`,
-          flaggingCount: redFlags.length,
-          riskLevel: RiskLevel.LOW_RISK, // TODO: Risk level calculation (20240201 - Shirley)
+        // Info: Find public tags with tag_type "9" matching search input (20240216 - Shirley)
+        const blacklistedAddresses = await prisma.public_tags.findMany({
+          where: {
+            ...whereClause,
+            target: {
+              startsWith: searchInput,
+            },
+            tag_type: TAG_TYPE.BLACKLIST,
+          },
+          take,
+          skip,
+          orderBy: [{created_timestamp: order}],
+
+          select: {
+            id: true,
+            name: true,
+            target: true,
+            target_type: true,
+            created_timestamp: true,
+          },
+        });
+
+        const contractTargets = blacklistedAddresses
+          .filter(tag => tag.target_type === '0')
+          .map(tag => tag.target as string);
+        const addressTargets = blacklistedAddresses
+          .filter(tag => tag.target_type === '1')
+          .map(tag => tag.target as string);
+
+        const contractsChainIds = await prisma.contracts.findMany({
+          where: {
+            contract_address: {in: contractTargets},
+          },
+          select: {
+            contract_address: true,
+            chain_id: true,
+          },
+        });
+
+        const addressesChainIds = await prisma.addresses.findMany({
+          where: {
+            address: {in: addressTargets},
+          },
+          select: {
+            address: true,
+            chain_id: true,
+            latest_active_time: true,
+          },
+        });
+
+        const chainIdMap = new Map();
+        const lastActiveTimeMap = new Map();
+        const addressTypeMap = new Map();
+
+        addressesChainIds.forEach(address => {
+          lastActiveTimeMap.set(address.address, address.latest_active_time);
+          addressTypeMap.set(address.address, AddressType.ADDRESS);
+        });
+
+        contractsChainIds.forEach(contract => {
+          chainIdMap.set(contract.contract_address, contract.chain_id);
+          addressTypeMap.set(contract.contract_address, AddressType.CONTRACT);
+        });
+        addressesChainIds.forEach(address => chainIdMap.set(address.address, address.chain_id));
+
+        blacklistedAddresses.forEach(item => {
+          const chainId = chainIdMap.get(item.target) ?? '';
+          const addressType = addressTypeMap.get(item.target) ?? AddressType.ADDRESS;
+
+          resultData.push({
+            type: SearchType.BLACKLIST,
+            data: {
+              id: `${item?.id}`,
+              chainId: `${chainId}`,
+              createdTimestamp: item?.created_timestamp ? item?.created_timestamp : 0,
+              address: `${item.target}`,
+              targetType: `${addressType}`,
+              latestActiveTime: lastActiveTimeMap.get(item.target) ?? 0,
+              tagName: `${item.name}`,
+            },
+          });
+        });
+      }
+    }
+  }
+
+  // Info: only return the first 10 data (20240305 - Shirley)
+  const result = resultData.slice(0, take);
+  return result;
+}
+
+async function countResultsByType(
+  type: string,
+  searchInput: string,
+  start_date?: number,
+  end_date?: number,
+  searchId?: number
+): Promise<number> {
+  // Function to count the results based on type and input without actually retrieving all data
+  // Use similar logic to searchByType but for counting
+  // Return the count as a number
+  switch (type) {
+    case SearchType.BLOCK:
+      // Count blocks matching the search input
+      // const searchId = isValid64BitInteger(searchInput) ? parseInt(searchInput, 10) : undefined;
+
+      const blocksCount = await prisma.blocks.count({
+        where: {
+          number: searchId,
         },
       });
-    });
 
-    // Info: Find public tags with tag_type "9" matching search input (20240216 - Shirley)
-    const blacklistedAddresses = await prisma.public_tags.findMany({
-      where: {
-        target: {
-          startsWith: searchInput,
-        },
-        tag_type: TAG_TYPE.BLACKLIST,
-      },
-      select: {
-        id: true,
-        name: true,
-        target: true,
-        target_type: true,
-        created_timestamp: true,
-      },
-    });
+      // eslint-disable-next-line no-console
+      console.log('blockCount', blocksCount);
+      return blocksCount;
 
-    const contractTargets = blacklistedAddresses
-      .filter(tag => tag.target_type === '0')
-      .map(tag => tag.target as string);
-    const addressTargets = blacklistedAddresses
-      .filter(tag => tag.target_type === '1')
-      .map(tag => tag.target as string);
-
-    const contractsChainIds = await prisma.contracts.findMany({
-      where: {
-        contract_address: {in: contractTargets},
-      },
-      select: {
-        contract_address: true,
-        chain_id: true,
-      },
-    });
-
-    const addressesChainIds = await prisma.addresses.findMany({
-      where: {
-        address: {in: addressTargets},
-      },
-      select: {
-        address: true,
-        chain_id: true,
-        latest_active_time: true,
-      },
-    });
-
-    const chainIdMap = new Map();
-    const lastActiveTimeMap = new Map();
-    const addressTypeMap = new Map();
-
-    addressesChainIds.forEach(address => {
-      lastActiveTimeMap.set(address.address, address.latest_active_time);
-      addressTypeMap.set(address.address, AddressType.ADDRESS);
-    });
-
-    contractsChainIds.forEach(contract => {
-      chainIdMap.set(contract.contract_address, contract.chain_id);
-      addressTypeMap.set(contract.contract_address, AddressType.CONTRACT);
-    });
-    addressesChainIds.forEach(address => chainIdMap.set(address.address, address.chain_id));
-
-    blacklistedAddresses.forEach(item => {
-      const chainId = chainIdMap.get(item.target) ?? '';
-      const addressType = addressTypeMap.get(item.target) ?? AddressType.ADDRESS;
-      const rs = {
-        type: SearchType.BLACKLIST,
-        data: {
-          id: `${item?.id}`,
-          chainId: `${chainId}`,
-          createdTimestamp: item?.created_timestamp ? item?.created_timestamp : 0,
-          address: `${item.target}`,
-          targetType: `${addressType}`,
-          latestActiveTime: lastActiveTimeMap.get(item.target) ?? 0,
-          tagName: `${item.name}`,
-        },
-      };
-
-      result.push({
-        type: SearchType.BLACKLIST,
-        data: {
-          id: `${item?.id}`,
-          chainId: `${chainId}`,
-          createdTimestamp: item?.created_timestamp ? item?.created_timestamp : 0,
-          address: `${item.target}`,
-          targetType: `${addressType}`,
-          latestActiveTime: lastActiveTimeMap.get(item.target) ?? 0,
-          tagName: `${item.name}`,
+      break;
+    case SearchType.TRANSACTION:
+      // Count transactions matching the search input
+      const transactionsCount = await prisma.transactions.count({
+        where: {
+          hash: {
+            startsWith: searchInput,
+          },
         },
       });
-    });
+      return transactionsCount;
+      break;
+    case SearchType.CONTRACT:
+      // Count contracts matching the search input
+      const contractsCount = await prisma.contracts.count({
+        where: {
+          contract_address: {
+            startsWith: searchInput,
+          },
+        },
+      });
+      return contractsCount;
+      break;
+    case SearchType.EVIDENCE:
+      // Count evidences matching the search input
+      const evidencesCount = await prisma.evidences.count({
+        where: {
+          OR: [
+            {evidence_id: {startsWith: searchInput}},
+            {contract_address: {startsWith: searchInput}},
+          ],
+        },
+      });
+      return evidencesCount;
+      break;
+    case SearchType.RED_FLAG:
+      // Count red flags matching the search input
+      const redFlagsCount = await prisma.red_flags.count({
+        where: {
+          related_addresses: {
+            hasSome: [`${searchInput}`],
+          },
+        },
+      });
+      return redFlagsCount;
+      break;
+    case SearchType.ADDRESS:
+      // Count addresses matching the search input
+      const addressesCount = await prisma.addresses.count({
+        where: {
+          address: {
+            startsWith: searchInput,
+          },
+        },
+      });
+      return addressesCount;
+      break;
+    case SearchType.BLACKLIST:
+      // Count blacklisted items matching the search input
+      const blacklistedAddressesCount = await prisma.public_tags.count({
+        where: {
+          target: {
+            startsWith: searchInput,
+          },
+          tag_type: TAG_TYPE.BLACKLIST,
+        },
+      });
+      return blacklistedAddressesCount;
+      break;
+    default:
+      // Count all types matching the search input
+      const countBlock = await prisma.blocks.count({
+        where: {
+          number: searchId,
+        },
+      });
 
-    res.status(200).json(result);
-  } catch (error) {
-    // Info: (20240130 - Shirley) Request error
-    // eslint-disable-next-line no-console
-    console.error('search result request', error);
-    res.status(500).json([] as ResponseData);
+      const countTx = await prisma.transactions.count({
+        where: {
+          hash: {
+            startsWith: searchInput,
+          },
+        },
+      });
+
+      const countContract = await prisma.contracts.count({
+        where: {
+          contract_address: {
+            startsWith: searchInput,
+          },
+        },
+      });
+
+      const countEvidence = await prisma.evidences.count({
+        where: {
+          OR: [
+            {evidence_id: {startsWith: searchInput}},
+            {contract_address: {startsWith: searchInput}},
+          ],
+        },
+      });
+
+      const countRedFlag = await prisma.red_flags.count({
+        where: {
+          related_addresses: {
+            hasSome: [`${searchInput}`],
+          },
+        },
+      });
+
+      const countAddress = await prisma.addresses.count({
+        where: {
+          address: {
+            startsWith: searchInput,
+          },
+        },
+      });
+
+      const countBlacklist = await prisma.public_tags.count({
+        where: {
+          target: {
+            startsWith: searchInput,
+          },
+          tag_type: TAG_TYPE.BLACKLIST,
+        },
+      });
+
+      return (
+        countBlock +
+        countTx +
+        countContract +
+        countEvidence +
+        countRedFlag +
+        countAddress +
+        countBlacklist
+      );
+
+      break;
   }
 }

--- a/src/pages/app/searching-result.tsx
+++ b/src/pages/app/searching-result.tsx
@@ -9,17 +9,29 @@ import DatePicker from '../../components/date_picker/date_picker';
 import SortingMenu from '../../components/sorting_menu/sorting_menu';
 import SearchingResultItem from '../../components/searching_result_item/searching_result_item';
 import Pagination from '../../components/pagination/pagination';
-import {sortOldAndNewOptions, ITEM_PER_PAGE, default30DayPeriod} from '../../constants/config';
+import {
+  sortOldAndNewOptions,
+  ITEM_PER_PAGE,
+  default30DayPeriod,
+  DEFAULT_PAGE,
+} from '../../constants/config';
 import {serverSideTranslations} from 'next-i18next/serverSideTranslations';
 import {useTranslation} from 'next-i18next';
 import {TranslateFunction} from '../../interfaces/locale';
-import {ISearchResult} from '../../interfaces/search_result';
+import {
+  ISearchResult,
+  ISearchResultData,
+  filterTabs,
+  filterTabsToSearchType,
+} from '../../interfaces/search_result';
 import GlobalSearch from '../../components/global_search/global_search';
 import {GetServerSideProps} from 'next';
 import {ParsedUrlQuery} from 'querystring';
 import Skeleton from '../../components/skeleton/skeleton';
 import useAPIWorker from '../../lib/hooks/use_api_worker';
 import {APIURL} from '../../constants/api_request';
+import {convertStringToSortingType} from '../../lib/common';
+import {SearchType} from '../../constants/search_type';
 
 interface ISearchingResultPageProps {
   searchQuery: string;
@@ -96,18 +108,10 @@ const SearchingResultPage = ({searchQuery}: ISearchingResultPageProps) => {
   const router = useRouter();
   const {search} = router.query;
   const keyWord = search ? search.toString() : '';
+  const {page} = router.query;
 
   const headTitle = `${t('SEARCHING_RESULT_PAGE.MAIN_TITLE')} - BAIFA`;
-  const filterTabs = [
-    'SEARCHING_RESULT_PAGE.ALL_TAB', // Info:(20231228 - Julian) All
-    'SEARCHING_RESULT_PAGE.BLOCKS_TAB', // Info:(20231228 - Julian) Blocks
-    'SEARCHING_RESULT_PAGE.ADDRESSES_TAB', // Info:(20231228 - Julian) Addresses
-    'SEARCHING_RESULT_PAGE.CONTRACTS_TAB', // Info:(20231228 - Julian) Contracts
-    'SEARCHING_RESULT_PAGE.EVIDENCES_TAB', // Info:(20231228 - Julian) Evidences
-    'SEARCHING_RESULT_PAGE.TRANSACTIONS_TAB', // Info:(20231228 - Julian) Transactions
-    'SEARCHING_RESULT_PAGE.BLACKLIST_TAB', // Info:(20231228 - Julian) Black List
-    'SEARCHING_RESULT_PAGE.RED_FLAGS_TAB', // Info:(20231228 - Julian) Red Flags
-  ];
+
   // Info: (20231114 - Julian) Sorting Menu Options
   const sortingOptions = ['SORTING.RELEVANCY', ...sortOldAndNewOptions];
   // Info: (20231114 - Julian) Filter Tabs Shadow
@@ -116,32 +120,45 @@ const SearchingResultPage = ({searchQuery}: ISearchingResultPageProps) => {
   const shadowClassNameR =
     'after:absolute after:-inset-1 after:ml-auto after:top-0 after:block xl:after:hidden after:w-5 after:bg-gradient-to-l after:from-black after:to-transparent';
 
-  const [filteredResult, setFilteredResult] = useState<ISearchResult[]>([]);
+  // const [filteredResult, setFilteredResult] = useState<ISearchResult[]>([]);
   // Info: (20231114 - Julian) Filter State
   const [searchText, setSearchText, searchTextRef] = useStateRef<string>(keyWord);
   const [sorting, setSorting] = useState(sortingOptions[0]);
   const [activeTab, setActiveTab] = useState(filterTabs[0]);
   const [period, setPeriod] = useState(default30DayPeriod);
   // Info: (20231114 - Julian) Pagination State
-  const [activePage, setActivePage] = useState(1);
-  const [totalPages, setTotalPages] = useState(Math.ceil(filteredResult.length / ITEM_PER_PAGE));
+  const [activePage, setActivePage] = useState(page ? +page : DEFAULT_PAGE);
+  // const [totalPages, setTotalPages] = useState(Math.ceil(filteredResult.length / ITEM_PER_PAGE));
+
+  // eslint-disable-next-line no-console
+  console.log('activeTab', activeTab, filterTabsToSearchType.get(activeTab));
 
   const getInputValue = (value: string) => {
     setSearchText(value);
   };
 
   // Info: (20231115 - Julian) Pagination Index
-  const endIdx = activePage * ITEM_PER_PAGE;
-  const startIdx = endIdx - ITEM_PER_PAGE;
+  // const endIdx = activePage * ITEM_PER_PAGE;
+  // const startIdx = endIdx - ITEM_PER_PAGE;
 
   const {
     data: searchResults,
     isLoading: isSearchLoading,
     error: searchError,
-  } = useAPIWorker<ISearchResult[]>(
+  } = useAPIWorker<ISearchResultData>(
     `${APIURL.SEARCH_RESULT}`,
     {
       search_input: searchTextRef.current,
+
+      start_date: period.startTimeStamp === 0 ? '' : period.startTimeStamp,
+      end_date: period.endTimeStamp === 0 ? '' : period.endTimeStamp,
+      order: convertStringToSortingType(sorting),
+      page: activePage,
+      offset: ITEM_PER_PAGE,
+      type: filterTabsToSearchType.get(activeTab) ?? SearchType.ALL,
+
+      // TODO: `ISearchType`, block, address, contract, evidence, transaction, blacklist, red_flag
+      // type: filteredType === 'SORTING.ALL' ? '' : filteredType,
     },
     true
   );
@@ -155,56 +172,56 @@ const SearchingResultPage = ({searchQuery}: ISearchingResultPageProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
-    if (!searchResults) return;
-    const result = searchResults
-      /* TODO: don't filter data out by string (20240229 - Shirley)
-      .filter(searchResults => {
-        return true;
-        // Info: (20231115 - Julian) filter by Search bar
-        
-        // const searchTerm = searchTextRef.current.toLowerCase();
-        // const id = searchResults.data.id.toLowerCase();
-        // const chainId = searchResults.data.chainId.toLowerCase();
-        // const type = searchResults.type.toLowerCase();
-        // return id.includes(searchTextRef.current);
-        // return searchTerm === ''
-        //   ? true
-        //   : id.includes(searchTerm) || chainId.includes(searchTerm) || type.includes(searchTerm);
-      })
-      */
-      .filter(searchResults => {
-        // Info: (20231115 - Julian) filter by Filter Tabs
-        const type = searchResults.type;
-        return activeTab === filterTabs[0] ? true : activeTab.includes(type);
-      })
-      .filter(searchResults => {
-        // Info: (20231115 - Julian) filter by Date Picker
-        const timestamp = searchResults.data.createdTimestamp;
-        const startTimeStamp = period.startTimeStamp;
-        const endTimeStamp = period.endTimeStamp;
-        return startTimeStamp !== 0 && endTimeStamp !== 0
-          ? timestamp >= startTimeStamp && timestamp <= endTimeStamp
-          : true;
-      })
-      .sort((a, b) => {
-        // Info: (20231115 - Julian) sort by Sorting Menu
-        return sorting === sortingOptions[0]
-          ? // ToDo: (20231115 - Julian) sort by Relevancy
-            0
-          : sorting === sortOldAndNewOptions[1]
-          ? a.data.createdTimestamp - b.data.createdTimestamp
-          : b.data.createdTimestamp - a.data.createdTimestamp;
-      });
+  // useEffect(() => {
+  //   // if (!searchResults) return;
+  //   // const result = searchResults
+  //   //   /* TODO: don't filter data out by string (20240229 - Shirley)
+  //   //   .filter(searchResults => {
+  //   //     return true;
+  //   //     // Info: (20231115 - Julian) filter by Search bar
 
-    setFilteredResult(result);
-    setTotalPages(Math.ceil(result.length / ITEM_PER_PAGE));
-    setActivePage(1);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchText, sorting, activeTab, period, searchResults]);
+  //   //     // const searchTerm = searchTextRef.current.toLowerCase();
+  //   //     // const id = searchResults.data.id.toLowerCase();
+  //   //     // const chainId = searchResults.data.chainId.toLowerCase();
+  //   //     // const type = searchResults.type.toLowerCase();
+  //   //     // return id.includes(searchTextRef.current);
+  //   //     // return searchTerm === ''
+  //   //     //   ? true
+  //   //     //   : id.includes(searchTerm) || chainId.includes(searchTerm) || type.includes(searchTerm);
+  //   //   })
+  //   //   */
+  //   //   .filter(searchResults => {
+  //   //     // Info: (20231115 - Julian) filter by Filter Tabs
+  //   //     const type = searchResults.type;
+  //   //     return activeTab === filterTabs[0] ? true : activeTab.includes(type);
+  //   //   })
+  //   //   .filter(searchResults => {
+  //   //     // Info: (20231115 - Julian) filter by Date Picker
+  //   //     const timestamp = searchResults.data.createdTimestamp;
+  //   //     const startTimeStamp = period.startTimeStamp;
+  //   //     const endTimeStamp = period.endTimeStamp;
+  //   //     return startTimeStamp !== 0 && endTimeStamp !== 0
+  //   //       ? timestamp >= startTimeStamp && timestamp <= endTimeStamp
+  //   //       : true;
+  //   //   })
+  //   //   .sort((a, b) => {
+  //   //     // Info: (20231115 - Julian) sort by Sorting Menu
+  //   //     return sorting === sortingOptions[0]
+  //   //       ? // ToDo: (20231115 - Julian) sort by Relevancy
+  //   //         0
+  //   //       : sorting === sortOldAndNewOptions[1]
+  //   //       ? a.data.createdTimestamp - b.data.createdTimestamp
+  //   //       : b.data.createdTimestamp - a.data.createdTimestamp;
+  //   //   });
+
+  //   // setFilteredResult(result);
+  //   // setTotalPages(Math.ceil(result.length / ITEM_PER_PAGE));
+  //   // setActivePage(1);
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, [searchText, sorting, activeTab, period, searchResults]);
 
   const resultList = !isSearchLoading
-    ? filteredResult.slice(startIdx, endIdx).map((searchResults, index) => {
+    ? searchResults?.data.map((searchResults, index) => {
         return <SearchingResultItem key={index} searchResult={searchResults} />;
       })
     : Array.from({length: ITEM_PER_PAGE}).map((_, index) => (
@@ -283,7 +300,7 @@ const SearchingResultPage = ({searchQuery}: ISearchingResultPageProps) => {
               <Pagination
                 activePage={activePage}
                 setActivePage={setActivePage}
-                totalPages={totalPages}
+                totalPages={searchResults?.totalPage ?? 0}
               />
             </div>
           </div>

--- a/src/pages/app/searching-result.tsx
+++ b/src/pages/app/searching-result.tsx
@@ -19,7 +19,6 @@ import {serverSideTranslations} from 'next-i18next/serverSideTranslations';
 import {useTranslation} from 'next-i18next';
 import {TranslateFunction} from '../../interfaces/locale';
 import {
-  ISearchResult,
   ISearchResultData,
   filterTabs,
   filterTabsToSearchType,
@@ -120,26 +119,18 @@ const SearchingResultPage = ({searchQuery}: ISearchingResultPageProps) => {
   const shadowClassNameR =
     'after:absolute after:-inset-1 after:ml-auto after:top-0 after:block xl:after:hidden after:w-5 after:bg-gradient-to-l after:from-black after:to-transparent';
 
-  // const [filteredResult, setFilteredResult] = useState<ISearchResult[]>([]);
   // Info: (20231114 - Julian) Filter State
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [searchText, setSearchText, searchTextRef] = useStateRef<string>(keyWord);
   const [sorting, setSorting] = useState(sortingOptions[0]);
   const [activeTab, setActiveTab] = useState(filterTabs[0]);
   const [period, setPeriod] = useState(default30DayPeriod);
   // Info: (20231114 - Julian) Pagination State
   const [activePage, setActivePage] = useState(page ? +page : DEFAULT_PAGE);
-  // const [totalPages, setTotalPages] = useState(Math.ceil(filteredResult.length / ITEM_PER_PAGE));
-
-  // eslint-disable-next-line no-console
-  console.log('activeTab', activeTab, filterTabsToSearchType.get(activeTab));
 
   const getInputValue = (value: string) => {
     setSearchText(value);
   };
-
-  // Info: (20231115 - Julian) Pagination Index
-  // const endIdx = activePage * ITEM_PER_PAGE;
-  // const startIdx = endIdx - ITEM_PER_PAGE;
 
   const {
     data: searchResults,
@@ -149,16 +140,12 @@ const SearchingResultPage = ({searchQuery}: ISearchingResultPageProps) => {
     `${APIURL.SEARCH_RESULT}`,
     {
       search_input: searchTextRef.current,
-
       start_date: period.startTimeStamp === 0 ? '' : period.startTimeStamp,
       end_date: period.endTimeStamp === 0 ? '' : period.endTimeStamp,
       order: convertStringToSortingType(sorting),
       page: activePage,
       offset: ITEM_PER_PAGE,
       type: filterTabsToSearchType.get(activeTab) ?? SearchType.ALL,
-
-      // TODO: `ISearchType`, block, address, contract, evidence, transaction, blacklist, red_flag
-      // type: filteredType === 'SORTING.ALL' ? '' : filteredType,
     },
     true
   );
@@ -171,54 +158,6 @@ const SearchingResultPage = ({searchQuery}: ISearchingResultPageProps) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // useEffect(() => {
-  //   // if (!searchResults) return;
-  //   // const result = searchResults
-  //   //   /* TODO: don't filter data out by string (20240229 - Shirley)
-  //   //   .filter(searchResults => {
-  //   //     return true;
-  //   //     // Info: (20231115 - Julian) filter by Search bar
-
-  //   //     // const searchTerm = searchTextRef.current.toLowerCase();
-  //   //     // const id = searchResults.data.id.toLowerCase();
-  //   //     // const chainId = searchResults.data.chainId.toLowerCase();
-  //   //     // const type = searchResults.type.toLowerCase();
-  //   //     // return id.includes(searchTextRef.current);
-  //   //     // return searchTerm === ''
-  //   //     //   ? true
-  //   //     //   : id.includes(searchTerm) || chainId.includes(searchTerm) || type.includes(searchTerm);
-  //   //   })
-  //   //   */
-  //   //   .filter(searchResults => {
-  //   //     // Info: (20231115 - Julian) filter by Filter Tabs
-  //   //     const type = searchResults.type;
-  //   //     return activeTab === filterTabs[0] ? true : activeTab.includes(type);
-  //   //   })
-  //   //   .filter(searchResults => {
-  //   //     // Info: (20231115 - Julian) filter by Date Picker
-  //   //     const timestamp = searchResults.data.createdTimestamp;
-  //   //     const startTimeStamp = period.startTimeStamp;
-  //   //     const endTimeStamp = period.endTimeStamp;
-  //   //     return startTimeStamp !== 0 && endTimeStamp !== 0
-  //   //       ? timestamp >= startTimeStamp && timestamp <= endTimeStamp
-  //   //       : true;
-  //   //   })
-  //   //   .sort((a, b) => {
-  //   //     // Info: (20231115 - Julian) sort by Sorting Menu
-  //   //     return sorting === sortingOptions[0]
-  //   //       ? // ToDo: (20231115 - Julian) sort by Relevancy
-  //   //         0
-  //   //       : sorting === sortOldAndNewOptions[1]
-  //   //       ? a.data.createdTimestamp - b.data.createdTimestamp
-  //   //       : b.data.createdTimestamp - a.data.createdTimestamp;
-  //   //   });
-
-  //   // setFilteredResult(result);
-  //   // setTotalPages(Math.ceil(result.length / ITEM_PER_PAGE));
-  //   // setActivePage(1);
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, [searchText, sorting, activeTab, period, searchResults]);
 
   const resultList = !isSearchLoading
     ? searchResults?.data.map((searchResults, index) => {

--- a/src/pages/app/searching-result.tsx
+++ b/src/pages/app/searching-result.tsx
@@ -44,7 +44,7 @@ const SearchingResultItemSkeleton = () => {
   return (
     <div className="">
       {/* Info: (20240223 - Shirley) Link */}
-      <div className="rounded-lg bg-darkPurple p-6 shadow-xl transition-all duration-300 ease-in-out hover:bg-purpleLinear lg:p-8">
+      <div className="rounded-lg bg-darkPurple p-6 shadow-xl transition-all duration-300 ease-in-out lg:p-8">
         {/* Info: (20240223 - Shirley) Title */}
         <div className="flex w-full items-center lg:w-4/5">
           {/* Info: (20240223 - Shirley) ID */}


### PR DESCRIPTION
### DEVELOP

- [x] 重構 search API ，將功能拆成兩個 function，將 data 跟 totalCount 依照 type 回傳對應的資料
- [x] search API 依照參數（[API-v1.1.0 文件](https://github.com/CAFECA-IO/BAIFA/wiki/API-v1.1.0#003---search-result)）回傳資料，將分頁功能實作在 API
- [x] 將 search API 用到的常數寫在 config，將需要用 codes table 動態對照的資料寫成 static object
- [x] 完善 address 的 risk record 跟 risk level 的搜尋功能，先在 addresses table 模糊搜尋 searchInput 後，把搜尋到的 addresses 拿來搜尋 red_flags table，然後再來算 risk record 數量跟對應的 risk level


### CHECK LIST

- [Naming convention](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md) verification: checked
- Coding style verification: checked
- new Library: 0
- new Class / Component:  0
- new loop: 2
    - src/pages/api/v1/app/search.ts (374, 762)
- high risk: 0
- new sql: 0
