### PR TITLE
refactor: 💡 revise the financial data type based on API doc (caveat: be able to merge after content data in evidence table is revised)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baifa",
-  "version": "0.1.1+31",
+  "version": "0.1.1+34",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/components/comprehensive_income_statements_neo/comprehensive_income_statements_neo.tsx
+++ b/src/components/comprehensive_income_statements_neo/comprehensive_income_statements_neo.tsx
@@ -103,8 +103,8 @@ const ComprehensiveIncomeStatementsNeo = ({
   const income_statements_p8_1 = createRevenueTable(
     'Spread fee',
     revenueDate,
-    currentIncomeData?.income.spreadFee,
-    previousIncomeData?.income.spreadFee,
+    currentIncomeData?.income.details.spreadFee,
+    previousIncomeData?.income.details.spreadFee,
     numeroOfSpreadFee
   );
 
@@ -133,8 +133,8 @@ const ComprehensiveIncomeStatementsNeo = ({
   const income_statements_p11_1 = createRevenueTable(
     'Liquidation fee',
     revenueDate,
-    currentIncomeData?.income.liquidationFee,
-    previousIncomeData?.income.liquidationFee,
+    currentIncomeData?.income.details.liquidationFee,
+    previousIncomeData?.income.details.liquidationFee,
     numeroOfLiquidationFee
   );
 
@@ -149,8 +149,8 @@ const ComprehensiveIncomeStatementsNeo = ({
   const income_statements_p12_1 = createRevenueTable(
     'Guaranteed stop-loss fee',
     revenueDate,
-    currentIncomeData?.income.guaranteedStopLossFee,
-    previousIncomeData?.income.guaranteedStopLossFee,
+    currentIncomeData?.income.details.guaranteedStopLossFee,
+    previousIncomeData?.income.details.guaranteedStopLossFee,
     numeroOfGuaranteedStopLossFee
   );
 

--- a/src/interfaces/balance_sheets_neo.ts
+++ b/src/interfaces/balance_sheets_neo.ts
@@ -94,3 +94,98 @@ export interface IBalanceSheetsResponse {
   currentReport: IBalanceSheetsNeo;
   previousReport: IBalanceSheetsNeo;
 }
+
+const fiatCurrencyDetailExample: IFiatCurrencyDetail = {
+  fairValue: "10000",
+  breakdown: {
+    USD: {
+      amount: "8000",
+      fairValue: "8000",
+    },
+  },
+};
+
+
+const cryptocurrencyDetailExample: ICryptocurrencyDetail = {
+  fairValue: "50000",
+  breakdown: {
+    BTC: {
+      amount: "1",
+      fairValue: "30000",
+    },
+    ETH: {
+      amount: "10",
+      fairValue: "15000",
+    },
+    USDT: {
+      amount: "5000",
+      fairValue: "5000",
+    },
+  },
+};
+
+
+const currencyDetailExample: ICurrencyDetail = {
+  fairValue: "60000",
+  breakdown: {
+    BTC: {
+      amount: "1.5",
+      fairValue: "45000",
+    },
+    ETH: {
+      amount: "20",
+      fairValue: "10000",
+    },
+    USDT: {
+      amount: "10000",
+      fairValue: "10000",
+    },
+    USD: {
+      amount: "5000",
+      fairValue: "5000",
+    },
+  },
+};
+
+
+export const balanceSheetsNeoExample: IBalanceSheetsNeo = {
+  reportID: "report_123",
+  reportName: "Q1 Financial Report",
+  reportStartTime: 1617235200, // 01 April 2021
+  reportEndTime: 1625097600, // 01 July 2021
+  reportType: "balance sheet",
+  totalAssetsFairValue: "150000",
+  totalLiabilitiesAndEquityFairValue: "150000",
+  assets: {
+    fairValue: "100000",
+    details: {
+      cryptocurrency: cryptocurrencyDetailExample,
+      cashAndCashEquivalent: fiatCurrencyDetailExample,
+      accountsReceivable: cryptocurrencyDetailExample,
+    },
+  },
+  nonAssets: {
+    fairValue: "0",
+  },
+  liabilities: {
+    fairValue: "30000",
+    details: {
+      userDeposit: currencyDetailExample,
+      accountsPayable: currencyDetailExample,
+    },
+  },
+  equity: {
+    fairValue: "20000",
+    details: {
+      retainedEarning: currencyDetailExample,
+      otherCapitalReserve: currencyDetailExample,
+    },
+  },
+};
+
+
+export const balanceSheetsResponseExample: IBalanceSheetsResponse = {
+  currentReport: balanceSheetsNeoExample,
+  previousReport: balanceSheetsNeoExample, 
+};
+

--- a/src/interfaces/comprehensive_income_neo.ts
+++ b/src/interfaces/comprehensive_income_neo.ts
@@ -29,10 +29,9 @@ const DetailsSchema = z.object({
   depositFee: IncomeAccountingDetailSchema,
   withdrawalFee: IncomeAccountingDetailSchema,
   tradingFee: IncomeAccountingDetailSchema,
-  // TODO: 討論文件->修改文件->修改 type (20240325 - Shirley)
-  // spreadFee: IncomeAccountingDetailSchema,
-  // liquidationFee: IncomeAccountingDetailSchema,
-  // guaranteedStopLossFee: IncomeAccountingDetailSchema,
+  spreadFee: IncomeAccountingDetailSchema,
+  liquidationFee: IncomeAccountingDetailSchema,
+  guaranteedStopLossFee: IncomeAccountingDetailSchema,
 });
 
 export const ComprehensiveIncomeNeoSchema = z.object({
@@ -46,9 +45,6 @@ export const ComprehensiveIncomeNeoSchema = z.object({
   income: z.object({
     weightedAverageCost: z.string(),
     details: DetailsSchema,
-    spreadFee: IncomeAccountingDetailSchema,
-    liquidationFee: IncomeAccountingDetailSchema,
-    guaranteedStopLossFee: IncomeAccountingDetailSchema,
   }),
 
   costs: z.object({
@@ -105,3 +101,98 @@ export interface IComprehensiveIncomeResponse {
   previousReport: IComprehensiveIncomeNeo;
   lastYearReport: IComprehensiveIncomeNeo;
 }
+
+const dummyBreakdown = {
+  USDT: {
+    amount: "1000",
+    weightedAverageCost: "0.99",
+  },
+  ETH: {
+    amount: "5",
+    weightedAverageCost: "2000",
+  },
+  BTC: {
+    amount: "1",
+    weightedAverageCost: "30000",
+  },
+  USD: {
+    amount: "500",
+    weightedAverageCost: "1",
+  },
+};
+
+const dummyIncomeAccountingDetail = {
+  weightedAverageCost: "1.00",
+  breakdown: dummyBreakdown,
+};
+
+const dummyDetails = {
+  depositFee: dummyIncomeAccountingDetail,
+  withdrawalFee: dummyIncomeAccountingDetail,
+  tradingFee: dummyIncomeAccountingDetail,
+  spreadFee: dummyIncomeAccountingDetail,
+  liquidationFee: dummyIncomeAccountingDetail,
+  guaranteedStopLossFee: dummyIncomeAccountingDetail,
+  
+};
+
+export const dummyComprehensiveIncomeNeo: IComprehensiveIncomeNeo = {
+  reportType: "comprehensive income",
+  reportID: "RPT123456",
+  reportName: "Comprehensive Income Report - March 2023",
+  reportStartTime: 1677628800, // March 1, 2023
+  reportEndTime: 1679887999, // March 31, 2023
+  netProfit: "15000",
+
+  income: {
+    weightedAverageCost: "0.95",
+    details: dummyDetails,
+
+  },
+
+  costs: {
+    weightedAverageCost: "0.90",
+    details: {
+      technicalProviderFee: dummyIncomeAccountingDetail,
+      marketDataProviderFee: {
+        weightedAverageCost: "0.85",
+      },
+      newCoinListingCost: {
+        weightedAverageCost: "0.80",
+      },
+    },
+  },
+  operatingExpenses: {
+    weightedAverageCost: "0.75",
+    details: {
+      salaries: "20000",
+      rent: "5000",
+      marketing: "3000",
+      rebateExpenses: dummyIncomeAccountingDetail,
+    },
+  },
+  financialCosts: {
+    weightedAverageCost: "0.70",
+    details: {
+      interestExpense: "1000",
+      fiatToCryptocurrencyConversionLosses: "500",
+      cryptocurrencyToFiatConversionLosses: "300",
+      fiatToFiatConversionLosses: "200",
+      cryptocurrencyForexLosses: dummyIncomeAccountingDetail,
+    },
+  },
+  otherGainLosses: {
+    weightedAverageCost: "0.65",
+    details: {
+      investmentGains: "800",
+      forexGains: "600",
+      cryptocurrencyGains: dummyIncomeAccountingDetail,
+    },
+  },
+};
+
+export const dummyComprehensiveIncomeResponse: IComprehensiveIncomeResponse = {
+  currentReport: dummyComprehensiveIncomeNeo,
+  previousReport: dummyComprehensiveIncomeNeo, 
+  lastYearReport: dummyComprehensiveIncomeNeo, 
+};

--- a/src/lib/reports/comprehensive_income_neo.ts
+++ b/src/lib/reports/comprehensive_income_neo.ts
@@ -130,8 +130,8 @@ export const createCISFirstPart = (
         rowType: RowType.bookkeeping,
         rowData: [
           'B012 Spread Fee',
-          `${roundToDecimal(+dataA.income.spreadFee.weightedAverageCost, 2)}`,
-          `${roundToDecimal(+dataB.income.spreadFee.weightedAverageCost, 2)}`,
+          `${roundToDecimal(+dataA.income.details.spreadFee.weightedAverageCost, 2)}`,
+          `${roundToDecimal(+dataB.income.details.spreadFee.weightedAverageCost, 2)}`,
         ],
       },
       {
@@ -154,16 +154,16 @@ export const createCISFirstPart = (
         rowType: RowType.bookkeeping,
         rowData: [
           'B013 Liquidation fee',
-          `${roundToDecimal(+dataA.income.liquidationFee.weightedAverageCost, 2)}`,
-          `${roundToDecimal(+dataB.income.liquidationFee.weightedAverageCost, 2)}`,
+          `${roundToDecimal(+dataA.income.details.liquidationFee.weightedAverageCost, 2)}`,
+          `${roundToDecimal(+dataB.income.details.liquidationFee.weightedAverageCost, 2)}`,
         ],
       },
       {
         rowType: RowType.bookkeeping,
         rowData: [
           'B014 Guaranteed stop-loss fee',
-          `${roundToDecimal(+dataA.income.guaranteedStopLossFee.weightedAverageCost, 2)}`,
-          `${roundToDecimal(+dataB.income.guaranteedStopLossFee.weightedAverageCost, 2)}`,
+          `${roundToDecimal(+dataA.income.details.guaranteedStopLossFee.weightedAverageCost, 2)}`,
+          `${roundToDecimal(+dataB.income.details.guaranteedStopLossFee.weightedAverageCost, 2)}`,
         ],
       },
       {
@@ -666,8 +666,8 @@ export const createRevenueChangeTable = (
   const lastYearTradingFee = +lastYearData.income.details.tradingFee.weightedAverageCost;
   const tradingFeeChange = getChange(thisYearTradingFee, lastYearTradingFee) * 100;
 
-  const thisYearSpreadFee = +thisYearData.income.spreadFee.weightedAverageCost;
-  const lastYearSpreadFee = +lastYearData.income.spreadFee.weightedAverageCost;
+  const thisYearSpreadFee = +thisYearData.income.details.spreadFee.weightedAverageCost;
+  const lastYearSpreadFee = +lastYearData.income.details.spreadFee.weightedAverageCost;
   const spreadFeeChange = getChange(thisYearSpreadFee, lastYearSpreadFee) * 100;
 
   const thisYearWithdrawalFee = +thisYearData.income.details.withdrawalFee.weightedAverageCost;
@@ -678,14 +678,14 @@ export const createRevenueChangeTable = (
   const lastYearDepositFee = +lastYearData.income.details.depositFee.weightedAverageCost;
   const depositFeeChange = getChange(thisYearDepositFee, lastYearDepositFee) * 100;
 
-  const thisYearLiquidationFee = +thisYearData.income.liquidationFee.weightedAverageCost;
-  const lastYearLiquidationFee = +lastYearData.income.liquidationFee.weightedAverageCost;
+  const thisYearLiquidationFee = +thisYearData.income.details.liquidationFee.weightedAverageCost;
+  const lastYearLiquidationFee = +lastYearData.income.details.liquidationFee.weightedAverageCost;
   const liquidationFeeChange = getChange(thisYearLiquidationFee, lastYearLiquidationFee) * 100;
 
   const thisYearGuaranteedStopLossFee =
-    +thisYearData.income.guaranteedStopLossFee.weightedAverageCost;
+    +thisYearData.income.details.guaranteedStopLossFee.weightedAverageCost;
   const lastYearGuaranteedStopLossFee =
-    +lastYearData.income.guaranteedStopLossFee.weightedAverageCost;
+    +lastYearData.income.details.guaranteedStopLossFee.weightedAverageCost;
   const guaranteedStopLossFeeChange =
     getChange(thisYearGuaranteedStopLossFee, lastYearGuaranteedStopLossFee) * 100;
 

--- a/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/balance_sheet.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/balance_sheet.ts
@@ -17,10 +17,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const previousEvidenceId = evidenceId;
 
   try {
-    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
-    // eslint-disable-next-line no-console
-    // console.log('balanceSheetsNeoExample',balanceSheetsNeoExample,'balanceSheetsNeoExample stringify',JSON.stringify(balanceSheetsNeoExample))
-    
+       
     // Info: (20240315 - Julian) 從 evidences 撈出 current reports
     const currentReports = await prisma.evidences.findFirst({
       where: {
@@ -34,11 +31,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const currentReportsObj: IEvidenceContent = JSON.parse(currentReports?.content ?? '');
     // Info: (20240315 - Julian) 撈出 balanceSheet
     const currentBalance = currentReportsObj.balanceSheet;
-    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
-    // eslint-disable-next-line no-console
-    // console.log('currentBalance', currentBalance,'currentBalance stringify',JSON.stringify(currentBalance));
-    // 'details.crypto',currentBalance.assets.details.cryptocurrency,''
-    // console.object
 
     const validateCurrentBalance = BalanceSheetsNeoSchema.safeParse(currentBalance);
     if (!validateCurrentBalance.success) {
@@ -61,9 +53,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const previousReportsObj: IEvidenceContent = JSON.parse(previousReports?.content ?? '');
     // Info: (20240315 - Julian) 撈出 balanceSheet
     const previousBalance = previousReportsObj.balanceSheet;
-    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
-    // eslint-disable-next-line no-console
-    // console.log('previousBalance', previousBalance);
 
     const validatePreviousBalance = BalanceSheetsNeoSchema.safeParse(previousBalance);
     if (!validatePreviousBalance.success) {

--- a/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/balance_sheet.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/balance_sheet.ts
@@ -5,6 +5,7 @@ import prisma from '../../../../../../../../../prisma/client';
 import {
   BalanceSheetsNeoSchema,
   IBalanceSheetsResponse,
+  balanceSheetsNeoExample,
 } from '../../../../../../../../interfaces/balance_sheets_neo';
 import {IEvidenceContent} from '../../../../../../../../interfaces/evidence';
 
@@ -12,11 +13,14 @@ type ResponseData = IBalanceSheetsResponse | undefined;
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ResponseData>) {
   const evidenceId = typeof req.query.evidence_id === 'string' ? req.query.evidence_id : undefined;
-
   // ToDo: (20240315 - Julian) 找出 30 天前的 evidenceId
   const previousEvidenceId = evidenceId;
 
   try {
+    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
+    // eslint-disable-next-line no-console
+    // console.log('balanceSheetsNeoExample',balanceSheetsNeoExample,'balanceSheetsNeoExample stringify',JSON.stringify(balanceSheetsNeoExample))
+    
     // Info: (20240315 - Julian) 從 evidences 撈出 current reports
     const currentReports = await prisma.evidences.findFirst({
       where: {
@@ -32,7 +36,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const currentBalance = currentReportsObj.balanceSheet;
     // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
     // eslint-disable-next-line no-console
-    console.log('currentBalance', currentBalance);
+    // console.log('currentBalance', currentBalance,'currentBalance stringify',JSON.stringify(currentBalance));
+    // 'details.crypto',currentBalance.assets.details.cryptocurrency,''
+    // console.object
 
     const validateCurrentBalance = BalanceSheetsNeoSchema.safeParse(currentBalance);
     if (!validateCurrentBalance.success) {
@@ -57,7 +63,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const previousBalance = previousReportsObj.balanceSheet;
     // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
     // eslint-disable-next-line no-console
-    console.log('previousBalance', previousBalance);
+    // console.log('previousBalance', previousBalance);
 
     const validatePreviousBalance = BalanceSheetsNeoSchema.safeParse(previousBalance);
     if (!validatePreviousBalance.success) {

--- a/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/cash_flow.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/cash_flow.ts
@@ -80,9 +80,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       previousReport: validatePreviousCash.data,
       lastYearReport: validateLastYearCash.data,
     };
-    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
-    // eslint-disable-next-line no-console
-    // console.log('cash flow result', result);
 
     return res.status(200).json(result);
   } catch (error) {

--- a/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/cash_flow.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/cash_flow.ts
@@ -82,7 +82,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     };
     // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
     // eslint-disable-next-line no-console
-    console.log('cash flow result', result);
+    // console.log('cash flow result', result);
 
     return res.status(200).json(result);
   } catch (error) {

--- a/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/comprehensive_income.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/comprehensive_income.ts
@@ -24,21 +24,6 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const currentIncomeValidationResult = ComprehensiveIncomeNeoSchema.safeParse(
       currentReportsObj.comprehensiveIncome
     );
-    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
-    // eslint-disable-next-line no-console
-    console.log('currentReportsObj stringify', JSON.stringify(currentReportsObj.comprehensiveIncome));
-    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
-    // eslint-disable-next-line no-console
-    console.log('dummyComprehensiveIncomeNeo stringify', JSON.stringify(dummyComprehensiveIncomeNeo));
-
-    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
-    // eslint-disable-next-line no-console
-    // console.log(
-    //   'currentReportsObj.comprehensiveIncome',
-    //   currentReportsObj.comprehensiveIncome,
-    //   'currentIncomeValidationResult',
-    //   currentIncomeValidationResult
-    // );
 
     if (!currentIncomeValidationResult.success) {
       // eslint-disable-next-line no-console

--- a/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/comprehensive_income.ts
+++ b/src/pages/api/v1/app/chains/[chains_id]/evidence/[evidence_id]/comprehensive_income.ts
@@ -5,6 +5,7 @@ import prisma from '../../../../../../../../../prisma/client';
 import {
   ComprehensiveIncomeNeoSchema,
   IComprehensiveIncomeResponse,
+  dummyComprehensiveIncomeNeo,
 } from '../../../../../../../../interfaces/comprehensive_income_neo';
 import {IEvidenceContent} from '../../../../../../../../interfaces/evidence';
 
@@ -23,15 +24,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     const currentIncomeValidationResult = ComprehensiveIncomeNeoSchema.safeParse(
       currentReportsObj.comprehensiveIncome
     );
+    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
+    // eslint-disable-next-line no-console
+    console.log('currentReportsObj stringify', JSON.stringify(currentReportsObj.comprehensiveIncome));
+    // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
+    // eslint-disable-next-line no-console
+    console.log('dummyComprehensiveIncomeNeo stringify', JSON.stringify(dummyComprehensiveIncomeNeo));
 
     // Deprecated: 開發用，確認報表格式都跟文件以及 DB 一樣之後就可以移除 (20240410 - Shirley)
     // eslint-disable-next-line no-console
-    console.log(
-      'currentReportsObj.comprehensiveIncome',
-      currentReportsObj.comprehensiveIncome,
-      'currentIncomeValidationResult',
-      currentIncomeValidationResult
-    );
+    // console.log(
+    //   'currentReportsObj.comprehensiveIncome',
+    //   currentReportsObj.comprehensiveIncome,
+    //   'currentIncomeValidationResult',
+    //   currentIncomeValidationResult
+    // );
 
     if (!currentIncomeValidationResult.success) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
 ### DEVELOP

- refactor: 💡 revise the data type of comprehensive income statement and balance sheet based on API doc ([API v1.1.0 文件](https://github.com/CAFECA-IO/BAIFA/wiki/API-v1.1.0))
- 注意：證據表中的內容資料修改後可以合併此 PR，否則會無法顯示 evidence page 的 balance sheet, comprehensive income statement，如下圖所示
![image](https://github.com/CAFECA-IO/BAIFA/assets/20677913/881c96ff-e4a0-4d76-b927-07529eb2a357)


### CHECK LIST

- [Naming convention](https://github.com/CAFECA-IO/WorkGuidelines/blob/main/technology/coding-convention/naming-convention.md) verification: checked
- Coding style verification: checked
- new Library: 0
- new Class / Component:  0
- new loop: 0
- high risk: 0
- new sql: 0
